### PR TITLE
Possible fix for indentation problem with for a,b,c in foo():

### DIFF
--- a/nim-mode.el
+++ b/nim-mode.el
@@ -798,7 +798,7 @@ skipped."
       ;; narrow to surrounding parentheses
       (nim-util-narrow-to-paren)
       (while (progn
-               (if (re-search-backward "[,;]" (line-beginning-position) t)
+               (if (re-search-backward "[:=]" (line-beginning-position) t)
                    (forward-char)
                  (beginning-of-line))
                (let ((state (syntax-ppss)))


### PR DESCRIPTION
I'm new enough to nim that I don't know if it works in all cases. There's nothing I found in the language (nim or python) that would explain the original code which makes me hesitant to call this a real fix.

The specific case that was giving me trouble was with the for loop:
for x,y,z in bla():
           ^ would indent to here (last comma) instead of a single indent