### PR TITLE
Fix indentation

### DIFF
--- a/nim-indent.el
+++ b/nim-indent.el
@@ -198,9 +198,8 @@ keyword
        ((let ((start (save-excursion
                        (back-to-indentation)
                        (nim-util-forward-comment -1)
-                       (cond ((member (char-before) '(?: ?=))
-                              (nim-nav-beginning-of-block))
-                             ((re-search-backward (nim-rx decl-block) (line-beginning-position) t)
+                       (cond ((or (member (char-before) '(?: ?=))
+                                  (looking-back (nim-rx decl-block) nil))
                               (nim-nav-beginning-of-block))))))
           (when start
             (cons :after-block-start start))))

--- a/nim-indent.el
+++ b/nim-indent.el
@@ -200,7 +200,10 @@ keyword
                        (nim-util-forward-comment -1)
                        (cond ((or (member (char-before) '(?: ?=))
                                   (looking-back (nim-rx decl-block) nil))
-                              (nim-nav-beginning-of-block))))))
+                              (nim-nav-beginning-of-block))
+                             ((looking-back (nim-rx line-end-indenters) nil)
+                              (back-to-indentation)
+                              (point))))))
           (when start
             (cons :after-block-start start))))
        ;; At dedenter statement.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -49,7 +49,9 @@
 (eval-when-compile
   (require 'cl))
 
+;; Order of loading
 (require 'nim-vars)
+(eval-and-compile (require 'nim-rx))
 (require 'nim-syntax)
 (require 'nim-util)
 (require 'nim-helper)

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -1,0 +1,143 @@
+;;; nim-rx.el ---
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'rx)
+(require 'cl-lib)
+(require 'nim-vars)
+
+(eval-and-compile
+  (defvar nim-rx-constituents
+    (let* ((constituents1
+            (cl-loop for (sym . kwd) in `((keyword           . ,nim-keywords)
+                                          (dedenter          . ("elif" "else" "of" "except" "finally"))
+                                          (type              . ,nim-types)
+                                          (exception         . ,nim-exceptions)
+                                          (constant          . ,nim-constants)
+                                          (builtin           . ,nim-builtins)
+                                          (defun             . ("proc" "method" "converter" "iterator" "template" "macro"))
+                                          (block-ender       . ("break" "continue" "raise" "return"))
+                                          (block-start-defun . ("proc" "method" "converter" "iterator"
+                                                                "template" "macro"
+                                                                "if" "elif" "else" "when" "while" "for" "of"
+                                                                "try" "except" "finally"
+                                                                "with" "block"
+                                                                "enum" "tuple" "object")))
+                     collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end)))))))
+           (constituents2 `((decl-block . ,(rx symbol-start
+                                               (or "type" "const" "var" "let" "import")
+                                               symbol-end
+                                               (* space)
+                                               (or "#" eol)))
+
+                            (symbol-name          . ,(rx (any letter ?_ ?–) (* (any word ?_ ?–))))
+                            (dec-number . ,(rx symbol-start
+                                               (1+ (in digit "_"))
+                                               (opt "." (in digit "_"))
+                                               (opt (any "eE") (1+ digit))
+                                               (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                               symbol-end))
+                            (hex-number . ,(rx symbol-start
+                                               (1+ (in xdigit "_"))
+                                               (opt "." (in xdigit "_"))
+                                               (opt (any "eE") (1+ xdigit))
+                                               (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                               symbol-end))
+                            (oct-number . ,(rx symbol-start
+                                               (1+ (in "0-7_"))
+                                               (opt "." (in "0-7_"))
+                                               (opt (any "eE") (1+ "0-7_"))
+                                               (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                               symbol-end))
+                            (bin-number . ,(rx symbol-start
+                                               (1+ (in "0-1_"))
+                                               (opt "." (in "0-1_"))
+                                               (opt (any "eE") (1+ "0-1_"))
+                                               (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                               symbol-end))
+                            (open-paren           . ,(rx (or "{" "[" "(")))
+                            (close-paren          . ,(rx (or "}" "]" ")")))
+                            (simple-operator      . ,(rx (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%)))
+                            ;; FIXME: rx should support (not simple-operator).
+                            (not-simple-operator  . ,(rx
+                                                      (not
+                                                       (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%))))
+                            ;; FIXME: Use regexp-opt.
+                            (operator             . ,(rx (or (1+ (in "-=+*/<>@$~&%|!?^.:\\"))
+                                                             (and
+                                                              symbol-start
+                                                              (or
+                                                               "and" "or" "not" "xor" "shl"
+                                                               "shr" "div" "mod" "in" "notin" "is"
+                                                               "isnot")
+                                                              symbol-end))))
+                            ;; FIXME: Use regexp-opt.
+                            (assignment-operator  . ,(rx (* (in "-=+*/<>@$~&%|!?^.:\\")) "="))
+                            (string-delimiter . ,(rx (and
+                                                      ;; Match even number of backslashes.
+                                                      (or (not (any ?\\ ?\' ?\")) point
+                                                          ;; Quotes might be preceded by a escaped quote.
+                                                          (and (or (not (any ?\\)) point) ?\\
+                                                               (* ?\\ ?\\) (any ?\' ?\")))
+                                                      (* ?\\ ?\\)
+                                                      ;; Match single or triple quotes of any kind.
+                                                      (group (or  "\"" "\"\"\"" "'" "'''")))))
+                            (coding-cookie . ,(rx line-start ?# (* space)
+                                                  (or
+                                                   ;; # coding=<encoding name>
+                                                   (: "coding" (or ?: ?=) (* space) (group-n 1 (+ (or word ?-))))
+                                                   ;; # -*- coding: <encoding name> -*-
+                                                   (: "-*-" (* space) "coding:" (* space)
+                                                      (group-n 1 (+ (or word ?-))) (* space) "-*-")
+                                                   ;; # vim: set fileencoding=<encoding name> :
+                                                   (: "vim:" (* space) "set" (+ space)
+                                                      "fileencoding" (* space) ?= (* space)
+                                                      (group-n 1 (+ (or word ?-))) (* space) ":")))))))
+      (append constituents1 constituents2))
+    "Additional Nim specific sexps for `nim-rx'.")
+
+  (defmacro nim-rx (&rest regexps)
+    "Nim mode specialized rx macro.
+This variant of `rx' supports common nim named REGEXPS."
+    (let ((rx-constituents (append nim-rx-constituents rx-constituents)))
+      (cond ((null regexps)
+             (error "No regexp"))
+            ((cdr regexps)
+             (rx-to-string `(and ,@regexps) t))
+            (t
+             (rx-to-string (car regexps) t)))))
+
+  (add-to-list 'nim-rx-constituents
+               (cons 'block-start (nim-rx (or decl-block block-start-defun))))
+
+  ;; Regular expression matching the end of line after with a block starts.
+  ;; If the end of a line matches this regular expression, the next
+  ;; line is considered an indented block.  Whitespaces at the end of a
+  ;; line are ignored.
+  (add-to-list 'nim-rx-constituents
+               (cons 'line-end-indenters
+                     (nim-rx (or "type" "const" "var" "let" "tuple" "object" "enum" ":"
+                                 (and defun (* (not (any ?=))) "=")
+                                 (and "object" (+ whitespace) "of" (+ whitespace) symbol-name)))))
+
+  ) ; end of eval-and-compile
+
+(provide 'nim-rx)
+;;; nim-rx.el ends here

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -25,16 +25,7 @@
 (require 'nim-vars)
 
 (add-to-list 'nim-rx-constituents
-             (cons 'block-start
-                   (nim-rx (or decl-block
-                               (and symbol-start
-                                    (or "proc" "method" "converter" "iterator"
-                                        "template" "macro"
-                                        "if" "elif" "else" "when" "while" "for" "of"
-                                        "try" "except" "finally"
-                                        "with" "block"
-                                        "enum" "tuple" "object")
-                                    symbol-end)))))
+             (cons 'block-start (nim-rx (or decl-block block-start-defun))))
 
 ;; Regular expression matching the end of line after with a block starts.
 ;; If the end of a line matches this regular expression, the next

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -22,20 +22,7 @@
 ;;
 
 ;;; Code:
-(require 'nim-vars)
-
-(add-to-list 'nim-rx-constituents
-             (cons 'block-start (nim-rx (or decl-block block-start-defun))))
-
-;; Regular expression matching the end of line after with a block starts.
-;; If the end of a line matches this regular expression, the next
-;; line is considered an indented block.  Whitespaces at the end of a
-;; line are ignored.
-(add-to-list 'nim-rx-constituents
-             (cons 'line-end-indenters
-                   (nim-rx (or "type" "const" "var" "let" "tuple" "object" "enum" ":"
-                               (and defun (* (not (any ?=))) "=")
-                               (and "object" (+ whitespace) "of" (+ whitespace) symbol-name)))))
+(eval-and-compile (require 'nim-rx))
 
 (defconst nim-font-lock-keywords
   `(;; note the BACKTICK, `

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -24,6 +24,18 @@
 ;;; Code:
 (require 'nim-vars)
 
+(add-to-list 'nim-rx-constituents
+             (cons 'block-start
+                   (nim-rx (or decl-block
+                               (and symbol-start
+                                    (or "proc" "method" "converter" "iterator"
+                                        "template" "macro"
+                                        "if" "elif" "else" "when" "while" "for" "of"
+                                        "try" "except" "finally"
+                                        "with" "block"
+                                        "enum" "tuple" "object")
+                                    symbol-end)))))
+
 (defvar nim-indent-indenters
   (nim-rx (or "type" "const" "var" "let" "tuple" "object" "enum" ":"
               (and defun (* (not (any ?=))) "=")

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -36,14 +36,15 @@
                                         "enum" "tuple" "object")
                                     symbol-end)))))
 
-(defvar nim-indent-indenters
-  (nim-rx (or "type" "const" "var" "let" "tuple" "object" "enum" ":"
-              (and defun (* (not (any ?=))) "=")
-              (and "object" (+ whitespace) "of" (+ whitespace) symbol-name)))
-  "Regular expression matching the end of line after with a block starts.
-If the end of a line matches this regular expression, the next
-line is considered an indented block.  Whitespaces at the end of a
-line are ignored.")
+;; Regular expression matching the end of line after with a block starts.
+;; If the end of a line matches this regular expression, the next
+;; line is considered an indented block.  Whitespaces at the end of a
+;; line are ignored.
+(add-to-list 'nim-rx-constituents
+             (cons 'line-end-indenters
+                   (nim-rx (or "type" "const" "var" "let" "tuple" "object" "enum" ":"
+                               (and defun (* (not (any ?=))) "=")
+                               (and "object" (+ whitespace) "of" (+ whitespace) symbol-name)))))
 
 (defconst nim-font-lock-keywords
   `(;; note the BACKTICK, `

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -133,7 +133,7 @@ Magic functions.")
   "Nim standard operators.")
 
 (defvar nim-rx-constituents
-  (let ((predefineds-keywords
+  (let ((constituents1
          (cl-loop for (sym . kwd) in `((keyword     . ,nim-keywords)
                                        (dedenter    . ("elif" "else" "of" "except" "finally"))
                                        (type        . ,nim-types)
@@ -143,7 +143,7 @@ Magic functions.")
                                        (defun       . ("proc" "method" "converter" "iterator" "template" "macro"))
                                        (block-ender . ("break" "continue" "raise" "return")))
                   collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end))))))))
-    (append predefineds-keywords
+    (append constituents1
             `((decl-block . ,(rx symbol-start
                                  (or "type" "const" "var" "let" "import")
                                  symbol-end

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -57,7 +57,61 @@
 
 (defconst nim-indent-offset 2 "Number of spaces per level of indentation.")
 
-;; Keywords
+(defvar nim-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "M-.") 'nim-goto-sym)
+    (define-key map (kbd "C-c h") 'nim-explain-sym)
+    (define-key map ":" 'nim-indent-electric-colon)
+    (define-key map "\C-c<" 'nim-indent-shift-left)
+    (define-key map "\C-c>" 'nim-indent-shift-right)
+    map))
+
+(defconst nim-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    ;; Give punctuation syntax to ASCII that normally has symbol
+    ;; syntax or has word syntax and isn't a letter.
+    (let ((symbol (string-to-syntax "_"))
+          (sst (standard-syntax-table)))
+      (dotimes (i 128)
+        (unless (= i ?_)
+          (if (equal symbol (aref sst i))
+              (modify-syntax-entry i "." table)))))
+    (modify-syntax-entry ?$ "." table)
+    (modify-syntax-entry ?% "." table)
+
+    ;; exceptions
+    (modify-syntax-entry ?# "<" table)
+    (modify-syntax-entry ?\n ">" table)
+    (modify-syntax-entry ?' "\"" table)
+    (modify-syntax-entry ?` "$" table)
+
+    ;; Parentheses
+    (modify-syntax-entry ?\[ "(]  " table)
+    (modify-syntax-entry ?\] ")[  " table)
+    (modify-syntax-entry ?\{ "(}  " table)
+    (modify-syntax-entry ?\} "){  " table)
+    (modify-syntax-entry ?\( "()  " table)
+    (modify-syntax-entry ?\) ")(  " table)
+
+    ;; ;; Documentation comment highlighting
+    ;; ;; (modify-syntax-entry ?\# ". 12b" nim-mode-syntax-table)
+    ;; ;; (modify-syntax-entry ?\n "> b" nim-mode-syntax-table)
+    ;; ;; Comment highlighting
+    ;; (modify-syntax-entry ?# "< b"  nim-mode-syntax-table)
+    ;; (modify-syntax-entry ?\n "> b" nim-mode-syntax-table)
+    ;; (modify-syntax-entry ?\' "w"  nim-mode-syntax-table)
+    ;; (modify-syntax-entry ?\" "|"  nim-mode-syntax-table)
+    table)
+  "Syntax table for Nim files.")
+
+(defvar nim-dotty-syntax-table
+  (let ((table (make-syntax-table nim-mode-syntax-table)))
+    (modify-syntax-entry ?. "w" table)
+    (modify-syntax-entry ?_ "w" table)
+    table)
+  "Dotty syntax table for Nim files.
+It makes underscores and dots word constituent chars.")
+
 (defconst nim-keywords
   '("addr" "and" "as" "asm" "atomic" "bind" "block" "break" "case"
     "cast" "const" "continue" "converter" "discard" "distinct" "div" "do"
@@ -131,162 +185,6 @@ Magic functions.")
 (defconst nim-operators
   '( "`" "{." ".}" "[" "]" "{" "}" "(" ")" )
   "Nim standard operators.")
-
-(defvar nim-rx-constituents
-  (let* ((constituents1
-          (cl-loop for (sym . kwd) in `((keyword           . ,nim-keywords)
-                                        (dedenter          . ("elif" "else" "of" "except" "finally"))
-                                        (type              . ,nim-types)
-                                        (exception         . ,nim-exceptions)
-                                        (constant          . ,nim-constants)
-                                        (builtin           . ,nim-builtins)
-                                        (defun             . ("proc" "method" "converter" "iterator" "template" "macro"))
-                                        (block-ender       . ("break" "continue" "raise" "return"))
-                                        (block-start-defun . ("proc" "method" "converter" "iterator"
-                                                              "template" "macro"
-                                                              "if" "elif" "else" "when" "while" "for" "of"
-                                                              "try" "except" "finally"
-                                                              "with" "block"
-                                                              "enum" "tuple" "object")))
-                   collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end)))))))
-         (constituents2 `((decl-block . ,(rx symbol-start
-                                             (or "type" "const" "var" "let" "import")
-                                             symbol-end
-                                             (* space)
-                                             (or "#" eol)))
-
-                          (symbol-name          . ,(rx (any letter ?_ ?–) (* (any word ?_ ?–))))
-                          (dec-number . ,(rx symbol-start
-                                             (1+ (in digit "_"))
-                                             (opt "." (in digit "_"))
-                                             (opt (any "eE") (1+ digit))
-                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                             symbol-end))
-                          (hex-number . ,(rx symbol-start
-                                             (1+ (in xdigit "_"))
-                                             (opt "." (in xdigit "_"))
-                                             (opt (any "eE") (1+ xdigit))
-                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                             symbol-end))
-                          (oct-number . ,(rx symbol-start
-                                             (1+ (in "0-7_"))
-                                             (opt "." (in "0-7_"))
-                                             (opt (any "eE") (1+ "0-7_"))
-                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                             symbol-end))
-                          (bin-number . ,(rx symbol-start
-                                             (1+ (in "0-1_"))
-                                             (opt "." (in "0-1_"))
-                                             (opt (any "eE") (1+ "0-1_"))
-                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                             symbol-end))
-                          (open-paren           . ,(rx (or "{" "[" "(")))
-                          (close-paren          . ,(rx (or "}" "]" ")")))
-                          (pragma               . ,(rx "{." (1+ any) ".}"))
-                          (simple-operator      . ,(rx (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%)))
-                          ;; FIXME: rx should support (not simple-operator).
-                          (not-simple-operator  . ,(rx
-                                                    (not
-                                                     (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%))))
-                          ;; FIXME: Use regexp-opt.
-                          (operator             . ,(rx (or (1+ (in "-=+*/<>@$~&%|!?^.:\\"))
-                                                           (and
-                                                            symbol-start
-                                                            (or
-                                                             "and" "or" "not" "xor" "shl"
-                                                             "shr" "div" "mod" "in" "notin" "is"
-                                                             "isnot")
-                                                            symbol-end))))
-                          ;; FIXME: Use regexp-opt.
-                          (assignment-operator  . ,(rx (* (in "-=+*/<>@$~&%|!?^.:\\")) "="))
-                          (string-delimiter . ,(rx (and
-                                                    ;; Match even number of backslashes.
-                                                    (or (not (any ?\\ ?\' ?\")) point
-                                                        ;; Quotes might be preceded by a escaped quote.
-                                                        (and (or (not (any ?\\)) point) ?\\
-                                                             (* ?\\ ?\\) (any ?\' ?\")))
-                                                    (* ?\\ ?\\)
-                                                    ;; Match single or triple quotes of any kind.
-                                                    (group (or  "\"" "\"\"\"" "'" "'''")))))
-                          (coding-cookie . ,(rx line-start ?# (* space)
-                                                (or
-                                                 ;; # coding=<encoding name>
-                                                 (: "coding" (or ?: ?=) (* space) (group-n 1 (+ (or word ?-))))
-                                                 ;; # -*- coding: <encoding name> -*-
-                                                 (: "-*-" (* space) "coding:" (* space)
-                                                    (group-n 1 (+ (or word ?-))) (* space) "-*-")
-                                                 ;; # vim: set fileencoding=<encoding name> :
-                                                 (: "vim:" (* space) "set" (+ space)
-                                                    "fileencoding" (* space) ?= (* space)
-                                                    (group-n 1 (+ (or word ?-))) (* space) ":")))))))
-    (append constituents1 constituents2))
-  "Additional Nim specific sexps for `nim-rx'.")
-
-(defmacro nim-rx (&rest regexps)
-    "Nim mode specialized rx macro.
-This variant of `rx' supports common nim named REGEXPS."
-    (let ((rx-constituents (append nim-rx-constituents rx-constituents)))
-      (cond ((null regexps)
-             (error "No regexp"))
-            ((cdr regexps)
-             (rx-to-string `(and ,@regexps) t))
-            (t
-             (rx-to-string (car regexps) t)))))
-
-(defvar nim-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "M-.") 'nim-goto-sym)
-    (define-key map (kbd "C-c h") 'nim-explain-sym)
-    (define-key map ":" 'nim-indent-electric-colon)
-    (define-key map "\C-c<" 'nim-indent-shift-left)
-    (define-key map "\C-c>" 'nim-indent-shift-right)
-    map))
-
-(defconst nim-mode-syntax-table
-  (let ((table (make-syntax-table)))
-    ;; Give punctuation syntax to ASCII that normally has symbol
-    ;; syntax or has word syntax and isn't a letter.
-    (let ((symbol (string-to-syntax "_"))
-          (sst (standard-syntax-table)))
-      (dotimes (i 128)
-        (unless (= i ?_)
-          (if (equal symbol (aref sst i))
-              (modify-syntax-entry i "." table)))))
-    (modify-syntax-entry ?$ "." table)
-    (modify-syntax-entry ?% "." table)
-
-    ;; exceptions
-    (modify-syntax-entry ?# "<" table)
-    (modify-syntax-entry ?\n ">" table)
-    (modify-syntax-entry ?' "\"" table)
-    (modify-syntax-entry ?` "$" table)
-
-    ;; Parentheses
-    (modify-syntax-entry ?\[ "(]  " table)
-    (modify-syntax-entry ?\] ")[  " table)
-    (modify-syntax-entry ?\{ "(}  " table)
-    (modify-syntax-entry ?\} "){  " table)
-    (modify-syntax-entry ?\( "()  " table)
-    (modify-syntax-entry ?\) ")(  " table)
-
-    ;; ;; Documentation comment highlighting
-    ;; ;; (modify-syntax-entry ?\# ". 12b" nim-mode-syntax-table)
-    ;; ;; (modify-syntax-entry ?\n "> b" nim-mode-syntax-table)
-    ;; ;; Comment highlighting
-    ;; (modify-syntax-entry ?# "< b"  nim-mode-syntax-table)
-    ;; (modify-syntax-entry ?\n "> b" nim-mode-syntax-table)
-    ;; (modify-syntax-entry ?\' "w"  nim-mode-syntax-table)
-    ;; (modify-syntax-entry ?\" "|"  nim-mode-syntax-table)
-    table)
-  "Syntax table for Nim files.")
-
-(defvar nim-dotty-syntax-table
-  (let ((table (make-syntax-table nim-mode-syntax-table)))
-    (modify-syntax-entry ?. "w" table)
-    (modify-syntax-entry ?_ "w" table)
-    table)
-  "Dotty syntax table for Nim files.
-It makes underscores and dots word constituent chars.")
 
 (provide 'nim-vars)
 ;;; nim-vars.el ends here

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -145,7 +145,7 @@ Magic functions.")
                   collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end))))))))
     (append predefineds-keywords
             `((decl-block . ,(rx symbol-start
-                                 (or "type" "const" "var" "let")
+                                 (or "type" "const" "var" "let" "import")
                                  symbol-end
                                  (* space)
                                  (or "#" eol)))

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -134,14 +134,20 @@ Magic functions.")
 
 (defvar nim-rx-constituents
   (let* ((constituents1
-          (cl-loop for (sym . kwd) in `((keyword     . ,nim-keywords)
-                                        (dedenter    . ("elif" "else" "of" "except" "finally"))
-                                        (type        . ,nim-types)
-                                        (exception   . ,nim-exceptions)
-                                        (constant    . ,nim-constants)
-                                        (builtin     . ,nim-builtins)
-                                        (defun       . ("proc" "method" "converter" "iterator" "template" "macro"))
-                                        (block-ender . ("break" "continue" "raise" "return")))
+          (cl-loop for (sym . kwd) in `((keyword           . ,nim-keywords)
+                                        (dedenter          . ("elif" "else" "of" "except" "finally"))
+                                        (type              . ,nim-types)
+                                        (exception         . ,nim-exceptions)
+                                        (constant          . ,nim-constants)
+                                        (builtin           . ,nim-builtins)
+                                        (defun             . ("proc" "method" "converter" "iterator" "template" "macro"))
+                                        (block-ender       . ("break" "continue" "raise" "return"))
+                                        (block-start-defun . ("proc" "method" "converter" "iterator"
+                                                              "template" "macro"
+                                                              "if" "elif" "else" "when" "while" "for" "of"
+                                                              "try" "except" "finally"
+                                                              "with" "block"
+                                                              "enum" "tuple" "object")))
                    collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end)))))))
          (constituents2 `((decl-block . ,(rx symbol-start
                                              (or "type" "const" "var" "let" "import")

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -133,87 +133,87 @@ Magic functions.")
   "Nim standard operators.")
 
 (defvar nim-rx-constituents
-  (let ((constituents1
-         (cl-loop for (sym . kwd) in `((keyword     . ,nim-keywords)
-                                       (dedenter    . ("elif" "else" "of" "except" "finally"))
-                                       (type        . ,nim-types)
-                                       (exception   . ,nim-exceptions)
-                                       (constant    . ,nim-constants)
-                                       (builtin     . ,nim-builtins)
-                                       (defun       . ("proc" "method" "converter" "iterator" "template" "macro"))
-                                       (block-ender . ("break" "continue" "raise" "return")))
-                  collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end))))))))
-    (append constituents1
-            `((decl-block . ,(rx symbol-start
-                                 (or "type" "const" "var" "let" "import")
-                                 symbol-end
-                                 (* space)
-                                 (or "#" eol)))
+  (let* ((constituents1
+          (cl-loop for (sym . kwd) in `((keyword     . ,nim-keywords)
+                                        (dedenter    . ("elif" "else" "of" "except" "finally"))
+                                        (type        . ,nim-types)
+                                        (exception   . ,nim-exceptions)
+                                        (constant    . ,nim-constants)
+                                        (builtin     . ,nim-builtins)
+                                        (defun       . ("proc" "method" "converter" "iterator" "template" "macro"))
+                                        (block-ender . ("break" "continue" "raise" "return")))
+                   collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end)))))))
+         (constituents2 `((decl-block . ,(rx symbol-start
+                                             (or "type" "const" "var" "let" "import")
+                                             symbol-end
+                                             (* space)
+                                             (or "#" eol)))
 
-
-              (symbol-name          . ,(rx (any letter ?_ ?–) (* (any word ?_ ?–))))
-              (dec-number . ,(rx symbol-start
-                                 (1+ (in digit "_"))
-                                 (opt "." (in digit "_"))
-                                 (opt (any "eE") (1+ digit))
-                                 (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                 symbol-end))
-              (hex-number . ,(rx symbol-start
-                                 (1+ (in xdigit "_"))
-                                 (opt "." (in xdigit "_"))
-                                 (opt (any "eE") (1+ xdigit))
-                                 (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                 symbol-end))
-              (oct-number . ,(rx symbol-start
-                                 (1+ (in "0-7_"))
-                                 (opt "." (in "0-7_"))
-                                 (opt (any "eE") (1+ "0-7_"))
-                                 (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                 symbol-end))
-              (bin-number . ,(rx symbol-start
-                                 (1+ (in "0-1_"))
-                                 (opt "." (in "0-1_"))
-                                 (opt (any "eE") (1+ "0-1_"))
-                                 (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
-                                 symbol-end))
-              (open-paren           . ,(rx (or "{." "{" "[" "(")))
-              (close-paren          . ,(rx (or ".}" "}" "]" ")")))
-              (simple-operator      . ,(rx (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%)))
-              ;; FIXME: rx should support (not simple-operator).
-              (not-simple-operator  . ,(rx
-                                        (not
-                                         (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%))))
-              ;; FIXME: Use regexp-opt.
-              (operator             . ,(rx (or (1+ (in "-=+*/<>@$~&%|!?^.:\\"))
-                                               (and
-                                                symbol-start
+                          (symbol-name          . ,(rx (any letter ?_ ?–) (* (any word ?_ ?–))))
+                          (dec-number . ,(rx symbol-start
+                                             (1+ (in digit "_"))
+                                             (opt "." (in digit "_"))
+                                             (opt (any "eE") (1+ digit))
+                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                             symbol-end))
+                          (hex-number . ,(rx symbol-start
+                                             (1+ (in xdigit "_"))
+                                             (opt "." (in xdigit "_"))
+                                             (opt (any "eE") (1+ xdigit))
+                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                             symbol-end))
+                          (oct-number . ,(rx symbol-start
+                                             (1+ (in "0-7_"))
+                                             (opt "." (in "0-7_"))
+                                             (opt (any "eE") (1+ "0-7_"))
+                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                             symbol-end))
+                          (bin-number . ,(rx symbol-start
+                                             (1+ (in "0-1_"))
+                                             (opt "." (in "0-1_"))
+                                             (opt (any "eE") (1+ "0-1_"))
+                                             (opt "'" (or "i8" "i16" "i32" "i64" "f32" "f64"))
+                                             symbol-end))
+                          (open-paren           . ,(rx (or "{" "[" "(")))
+                          (close-paren          . ,(rx (or "}" "]" ")")))
+                          (pragma               . ,(rx "{." (1+ any) ".}"))
+                          (simple-operator      . ,(rx (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%)))
+                          ;; FIXME: rx should support (not simple-operator).
+                          (not-simple-operator  . ,(rx
+                                                    (not
+                                                     (any ?+ ?- ?/ ?& ?^ ?~ ?| ?* ?< ?> ?= ?%))))
+                          ;; FIXME: Use regexp-opt.
+                          (operator             . ,(rx (or (1+ (in "-=+*/<>@$~&%|!?^.:\\"))
+                                                           (and
+                                                            symbol-start
+                                                            (or
+                                                             "and" "or" "not" "xor" "shl"
+                                                             "shr" "div" "mod" "in" "notin" "is"
+                                                             "isnot")
+                                                            symbol-end))))
+                          ;; FIXME: Use regexp-opt.
+                          (assignment-operator  . ,(rx (* (in "-=+*/<>@$~&%|!?^.:\\")) "="))
+                          (string-delimiter . ,(rx (and
+                                                    ;; Match even number of backslashes.
+                                                    (or (not (any ?\\ ?\' ?\")) point
+                                                        ;; Quotes might be preceded by a escaped quote.
+                                                        (and (or (not (any ?\\)) point) ?\\
+                                                             (* ?\\ ?\\) (any ?\' ?\")))
+                                                    (* ?\\ ?\\)
+                                                    ;; Match single or triple quotes of any kind.
+                                                    (group (or  "\"" "\"\"\"" "'" "'''")))))
+                          (coding-cookie . ,(rx line-start ?# (* space)
                                                 (or
-                                                 "and" "or" "not" "xor" "shl"
-                                                 "shr" "div" "mod" "in" "notin" "is"
-                                                 "isnot")
-                                                symbol-end))))
-              ;; FIXME: Use regexp-opt.
-              (assignment-operator  . ,(rx (* (in "-=+*/<>@$~&%|!?^.:\\")) "="))
-              (string-delimiter . ,(rx (and
-                                        ;; Match even number of backslashes.
-                                        (or (not (any ?\\ ?\' ?\")) point
-                                            ;; Quotes might be preceded by a escaped quote.
-                                            (and (or (not (any ?\\)) point) ?\\
-                                                 (* ?\\ ?\\) (any ?\' ?\")))
-                                        (* ?\\ ?\\)
-                                        ;; Match single or triple quotes of any kind.
-                                        (group (or  "\"" "\"\"\"" "'" "'''")))))
-              (coding-cookie . ,(rx line-start ?# (* space)
-                                    (or
-                                     ;; # coding=<encoding name>
-                                     (: "coding" (or ?: ?=) (* space) (group-n 1 (+ (or word ?-))))
-                                     ;; # -*- coding: <encoding name> -*-
-                                     (: "-*-" (* space) "coding:" (* space)
-                                        (group-n 1 (+ (or word ?-))) (* space) "-*-")
-                                     ;; # vim: set fileencoding=<encoding name> :
-                                     (: "vim:" (* space) "set" (+ space)
-                                        "fileencoding" (* space) ?= (* space)
-                                        (group-n 1 (+ (or word ?-))) (* space) ":")))))))
+                                                 ;; # coding=<encoding name>
+                                                 (: "coding" (or ?: ?=) (* space) (group-n 1 (+ (or word ?-))))
+                                                 ;; # -*- coding: <encoding name> -*-
+                                                 (: "-*-" (* space) "coding:" (* space)
+                                                    (group-n 1 (+ (or word ?-))) (* space) "-*-")
+                                                 ;; # vim: set fileencoding=<encoding name> :
+                                                 (: "vim:" (* space) "set" (+ space)
+                                                    "fileencoding" (* space) ?= (* space)
+                                                    (group-n 1 (+ (or word ?-))) (* space) ":")))))))
+    (append constituents1 constituents2))
   "Additional Nim specific sexps for `nim-rx'.")
 
 (defmacro nim-rx (&rest regexps)

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -132,7 +132,7 @@ Magic functions.")
   '( "`" "{." ".}" "[" "]" "{" "}" "(" ")" )
   "Nim standard operators.")
 
-(defconst nim-rx-constituents
+(defvar nim-rx-constituents
   (let ((predefineds-keywords
          (cl-loop for (sym . kwd) in `((keyword     . ,nim-keywords)
                                        (dedenter    . ("elif" "else" "of" "except" "finally"))
@@ -144,22 +144,7 @@ Magic functions.")
                                        (block-ender . ("break" "continue" "raise" "return")))
                   collect (cons sym (apply `((lambda () (rx symbol-start (or ,@kwd) symbol-end))))))))
     (append predefineds-keywords
-            `(
-              (block-start          . ,(rx (or (and symbol-start
-                                                    (or "type" "const" "var" "let")
-                                                    symbol-end
-                                                    (* space)
-                                                    (or "#" eol))
-                                               (and symbol-start
-                                                    (or "proc" "method" "converter" "iterator"
-                                                        "template" "macro"
-                                                        "if" "elif" "else" "when" "while" "for" "of"
-                                                        "try" "except" "finally"
-                                                        "with" "block"
-                                                        "enum" "tuple" "object")
-                                                    symbol-end))))
-
-              (decl-block . ,(rx symbol-start
+            `((decl-block . ,(rx symbol-start
                                  (or "type" "const" "var" "let")
                                  symbol-end
                                  (* space)

--- a/tests/samples/import-statement-actual.nim
+++ b/tests/samples/import-statement-actual.nim
@@ -1,0 +1,3 @@
+import
+parseutils, strutils, parseopt, parsecfg, strtabs, unicode, pegs, ropes,
+os, osproc, times

--- a/tests/samples/import-statement-expected.nim
+++ b/tests/samples/import-statement-expected.nim
@@ -1,0 +1,3 @@
+import
+  parseutils, strutils, parseopt, parsecfg, strtabs, unicode, pegs, ropes,
+  os, osproc, times

--- a/tests/samples/line-end-indent-actual.nim
+++ b/tests/samples/line-end-indent-actual.nim
@@ -1,0 +1,18 @@
+type
+  Node = ref NodeObj
+  NodeObj {.acyclic, final.} = object
+  left, right: Node
+  data: string
+
+type
+  Direction = enum
+  north, east, south, west
+
+type
+  Person = tuple   # type representing a person
+  name: string   # a person consists of a name
+  age: natural   # and an age
+
+type
+  Unit = ref object of Thing
+  x: int

--- a/tests/samples/line-end-indent-expected.nim
+++ b/tests/samples/line-end-indent-expected.nim
@@ -1,0 +1,18 @@
+type
+  Node = ref NodeObj
+  NodeObj {.acyclic, final.} = object
+    left, right: Node
+    data: string
+
+type
+  Direction = enum
+    north, east, south, west
+
+type
+  Person = tuple   # type representing a person
+    name: string   # a person consists of a name
+    age: natural   # and an age
+
+type
+  Unit = ref object of Thing
+    x: int

--- a/tests/test-indent.el
+++ b/tests/test-indent.el
@@ -50,3 +50,8 @@
  "should indent after ‘object’, ‘enum’, ‘tupel’, and ‘object of’ correctly"
  "tests/samples/line-end-indent"))
 
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+;;; test-indent.el ends here

--- a/tests/test-indent.el
+++ b/tests/test-indent.el
@@ -40,4 +40,8 @@
 
 (indent-and-compare
   "should dedent let/comments correctly"
-  "tests/samples/line-checking"))
+  "tests/samples/line-checking")
+
+(indent-and-compare
+ "should indent import statement's libraries correctly"
+ "tests/samples/import-statement"))

--- a/tests/test-indent.el
+++ b/tests/test-indent.el
@@ -44,4 +44,9 @@
 
 (indent-and-compare
  "should indent import statement's libraries correctly"
- "tests/samples/import-statement"))
+ "tests/samples/import-statement")
+
+(indent-and-compare
+ "should indent after ‘object’, ‘enum’, ‘tupel’, and ‘object of’ correctly"
+ "tests/samples/line-end-indent"))
+


### PR DESCRIPTION
Sorry, when I made #35, I had been avoided your indentation logic about "object", "tuple", "enum" and "object of". This PR fixes those indentation.
Also I found that "import" statement didn't work well, so I fixed it too.

Lastly I moved `nim-rx-* ` related variables to nim-rx.el because those variables needs `eval-and-compile` and it's easy to maintain if those are same file.

I wish you like this refactoring:)

Thanks