### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: emacs-lisp
+sudo: required
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/7736123/raw | sh
+  - export PATH="/home/travis/.cask/bin:$PATH"
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - evm install $EVM_EMACS --use --skip
+  - cask
+env:
+  - EVM_EMACS=emacs-24.1-bin
+  - EVM_EMACS=emacs-24.2-bin
+  - EVM_EMACS=emacs-24.3-bin
+  - EVM_EMACS=emacs-24.4-bin
+script:
+  - emacs --version
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
   - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  - EVM_EMACS=emacs-24.1-bin
-  - EVM_EMACS=emacs-24.2-bin
   - EVM_EMACS=emacs-24.3-bin
   - EVM_EMACS=emacs-24.4-bin
 script:

--- a/Cask
+++ b/Cask
@@ -5,5 +5,6 @@
 
 (development
  (depends-on "buttercup")
- (depends-on "epc"))
-             
+ (depends-on "epc")
+ (depends-on "cl-lib"))
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+CASK ?= cask
+EMACS ?= emacs
+
+all: test
+
+test: clean-elc
+	${MAKE} unit
+	${MAKE} compile
+	${MAKE} unit
+	${MAKE} clean-elc
+
+compile:
+	${CASK} exec ${EMACS} -Q -batch -f batch-byte-compile *.el
+
+unit:
+	${CASK} exec buttercup -L .
+
+install:
+	${CASK} install
+
+clean-elc:
+	rm -f *.elc


### PR DESCRIPTION
Hi, working with travis is much easier to check building status.
I added basic settings and I checked that 24.3 and 24.4 were doing
tests. (But a test was failed. Other 8/9 were fine.)

Old version's Emacs 24.1 and 24.2 weren't working the test on Travis.
Probably need research???
But if you don't support old version's Emacs, you can exclude from
your test by just comment out below setting of .travis.yml.

```sh
  ...
  - EVM_EMACS=emacs-24.1-bin
  - EVM_EMACS=emacs-24.2-bin
  ...
```