### PR TITLE
Skip installation of dependencies if .cask is exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 CASK ?= cask
 EMACS ?= emacs
 
+cask_dir_exists := $(shell find ./ -type d -name ".cask")
+
 all: test
 
 test: clean-elc
-	${MAKE} install-dependencies
+	$(if $(cask_dir_exists), $(skip), ${MAKE} install-dependencies)
 	${MAKE} unit
 	${MAKE} compile
 	${MAKE} unit
@@ -21,3 +23,8 @@ install-dependencies:
 
 clean-elc:
 	rm -f *.elc
+
+define skip
+	@echo ".cask already exists, dependecies' installation skipped."
+	@echo "If you want to update those dependencies, execute `make install-dependencies`."
+endef


### PR DESCRIPTION
I would skip the cask install when I already have it because installing those packages need some
time. (I frequently type `make test` before I send PR)