### PR TITLE
Indent after colon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,5 @@ clean-elc:
 
 define skip
 	@echo ".cask already exists, dependecies' installation skipped."
-	@echo "If you want to update those dependencies, execute `make install-dependencies`."
+	@echo "If you want to update those dependencies, execute 'make install-dependencies'."
 endef

--- a/nim-indent.el
+++ b/nim-indent.el
@@ -211,7 +211,7 @@ keyword
                                         (and (looking-at (nim-rx cond-block))
                                              (not (nim-helper-line-contain-p ?:)))))
                                     result
-                                  (nim-nav-beginning-of-block))))
+                                  (nim-nav-beginning-of-statement))))
                              ((looking-back (nim-rx line-end-indenters) nil)
                               (back-to-indentation)
                               (point))))))
@@ -234,15 +234,6 @@ keyword
                                (+ (point) nim-uncompleted-condition-indent))))))))
           (when start
             (cons :after-uncompleted-condition start))))
-       ;; After general block (after ":")
-       ((let ((start (save-excursion
-                       (back-to-indentation)
-                       (nim-util-forward-comment -1)
-                       (when (eq ?: (char-before (point)))
-                         (forward-line -1)
-                         (+ 1 (point-at-bol) (current-indentation))))))
-          (when start
-            (cons :after-general-block-start start))))
        ;; After normal line, comment or ender (default case).
        ((save-excursion
           (back-to-indentation)
@@ -287,7 +278,6 @@ possibilities can be narrowed to specific indentation points."
                                (current-indentation))))
            (max line-indentation base-indent)))
         (`(,(or :after-block-start
-                :after-general-block-start
                 :after-backslash-first-line
                 :inside-paren-newline-start) . ,start)
          ;; Add one indentation level.

--- a/nim-indent.el
+++ b/nim-indent.el
@@ -233,6 +233,15 @@ keyword
                                (+ (point) nim-uncompleted-condition-indent))))))))
           (when start
             (cons :after-uncompleted-condition start))))
+       ;; After general block (after ":")
+       ((let ((start (save-excursion
+                       (back-to-indentation)
+                       (nim-util-forward-comment -1)
+                       (when (eq ?: (char-before (point)))
+                         (forward-line -1)
+                         (+ 1 (point-at-bol) (current-indentation))))))
+          (when start
+            (cons :after-general-block-start start))))
        ;; After normal line, comment or ender (default case).
        ((save-excursion
           (back-to-indentation)
@@ -277,6 +286,7 @@ possibilities can be narrowed to specific indentation points."
                                (current-indentation))))
            (max line-indentation base-indent)))
         (`(,(or :after-block-start
+                :after-general-block-start
                 :after-backslash-first-line
                 :inside-paren-newline-start) . ,start)
          ;; Add one indentation level.

--- a/tests/indents/indent-after-colon-actual.nim
+++ b/tests/indents/indent-after-colon-actual.nim
@@ -30,3 +30,8 @@ echo "should indent after colon"
 discard "End of colon should be ignored :
 This line should not indented.
 "
+
+# macro
+dumpTree:
+foo:
+x = "bar"

--- a/tests/indents/indent-after-colon-actual.nim
+++ b/tests/indents/indent-after-colon-actual.nim
@@ -1,0 +1,32 @@
+# This test checks indentation after ":"
+
+# defer statement
+defer:
+echo("should indent after colon")
+
+defer: # comment's colon :
+echo("should indent above line has comment")
+
+# Do notation
+sort(cities) do (x,y: string) -> int:
+cmp(x.len, y.len)
+
+cities = cities.map do (x:string) -> string:
+"City of " & x
+
+# Template
+template withFile(f, fn, mode: expr, actions: stmt): stmt {.immediate.} =
+block:
+var f: File  # since 'f' is a template param, it's injected implicitly
+
+withFile(txt, "test.txt", fmWrite):
+txt.writeln("should indent after colon")
+
+# static statement
+static:
+echo "should indent after colon"
+
+# string
+discard "End of colon should be ignored :
+This line should not indented.
+"

--- a/tests/indents/indent-after-colon-expected.nim
+++ b/tests/indents/indent-after-colon-expected.nim
@@ -30,3 +30,8 @@ static:
 discard "End of colon should be ignored :
 This line should not indented.
 "
+
+# macro
+dumpTree:
+  foo:
+    x = "bar"

--- a/tests/indents/indent-after-colon-expected.nim
+++ b/tests/indents/indent-after-colon-expected.nim
@@ -1,0 +1,32 @@
+# This test checks indentation after ":"
+
+# defer statement
+defer:
+  echo("should indent after colon")
+
+defer: # comment's colon :
+  echo("should indent above line has comment")
+
+# Do notation
+sort(cities) do (x,y: string) -> int:
+  cmp(x.len, y.len)
+
+cities = cities.map do (x:string) -> string:
+  "City of " & x
+
+# Template
+template withFile(f, fn, mode: expr, actions: stmt): stmt {.immediate.} =
+  block:
+    var f: File  # since 'f' is a template param, it's injected implicitly
+
+withFile(txt, "test.txt", fmWrite):
+  txt.writeln("should indent after colon")
+
+# static statement
+static:
+  echo "should indent after colon"
+
+# string
+discard "End of colon should be ignored :
+This line should not indented.
+"

--- a/tests/test-indent.el
+++ b/tests/test-indent.el
@@ -73,6 +73,10 @@
   "tests/indents/uncompleted-condition-stmt+1"
   :uncompleted-indent 'stmt+1)
 
+ (indent-and-compare
+  "should indent after colon correctly"
+  "tests/indents/indent-after-colon")
+
  )                                      ; keep this here for less changes
 
 ;; Local Variables:


### PR DESCRIPTION
This PR enables indentation after ":". 
Originally, I thought supporting template's indentation, but it indents
other nim-mode's missing indentation. (like defer)

Please correct me if there are another usage of ":"
 (I'm still learning Nim)