### PR TITLE
Fix indent

### DIFF
--- a/nim-helper.el
+++ b/nim-helper.el
@@ -964,12 +964,15 @@ default to utf-8."
   "Return non-nil if the current line has CHAR.
 But, string-face's CHAR is ignored.  If you set POS, the check starts from POS."
   (save-excursion
-    (goto-char pos)
-    (while (not (eolp))
-      (when (and (not (nth 3 (syntax-ppss)))
-                 (eq char (char-before (1+ (point)))))
-        (cl-return t))
-      (forward-char))))
+    (catch 'exit
+      (when pos (goto-char pos))
+      (while (not (eolp))
+        (let ((ppss (syntax-ppss)))
+          (when (and (not (nth 3 ppss))
+                     (not (nth 4 ppss))
+                     (eq char (char-after (point))))
+            (throw 'exit (point)))
+          (forward-char))))))
 
 (provide 'nim-helper)
 ;;; nim-helper.el ends here

--- a/nim-indent.el
+++ b/nim-indent.el
@@ -208,7 +208,8 @@ keyword
                                       (back-to-indentation)
                                       (when (not (looking-at (nim-rx cond-block)))
                                         (setq result (nim-nav-backward-block))
-                                        (looking-at (nim-rx cond-block))))
+                                        (and (looking-at (nim-rx cond-block))
+                                             (not (nim-helper-line-contain-p ?:)))))
                                     result
                                   (nim-nav-beginning-of-block))))
                              ((looking-back (nim-rx line-end-indenters) nil)

--- a/tests/indents/for-pairs-actual.nim
+++ b/tests/indents/for-pairs-actual.nim
@@ -1,4 +1,7 @@
 for x, y in foo:
 bar
 
-baz
+proc test() =
+if true:
+for x in obj:
+echo "should indent after `if` statement"

--- a/tests/indents/for-pairs-expected.nim
+++ b/tests/indents/for-pairs-expected.nim
@@ -1,4 +1,7 @@
 for x, y in foo:
   bar
 
-baz
+proc test() =
+  if true:
+    for x in obj:
+      echo "should indent after `if` statement"


### PR DESCRIPTION
Sorry, #53 had a bug when I indent following case:

```nim
if true:
  for x in obj:
     echo "this line doesn't indent..."
```