### PR TITLE
Remove cl.el dependency

### DIFF
--- a/company-nim.el
+++ b/company-nim.el
@@ -1,4 +1,4 @@
-;;; company-nim.el --- company backend for nim
+;;; company-nim.el --- company backend for nim -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2015  Simon Hafner
 
@@ -82,16 +82,14 @@
   (mapcar #'company-nim--format-candidate
           (if (string-equal arg ".")
               candidates
-            (remove-if-not
+            (cl-remove-if-not
              (lambda (c) (company-nim-fuzzy-match arg (car (last (nim-epc-qualifiedPath c)))))
              candidates))))
 
 
 (defun company-nim-candidates (arg callback)
   (when (derived-mode-p 'nim-mode)
-    (lexical-let ((cb callback)
-                  (local-arg arg))
-      (nim-call-epc 'sug (lambda (x) (funcall cb (company-nim--format-candidates local-arg x)))))))
+    (nim-call-epc 'sug (lambda (x) (funcall callback (company-nim--format-candidates arg x))))))
 
 
 (defun company-nim-prefix ()
@@ -108,7 +106,7 @@
 (defun company-nim-annotation (cand)
   (let ((ann (get-text-property 0 :nim-type cand))
         (symbol (get-text-property 0 :nim-sig cand)))
-    (format " %s [%s]" (substring ann 0 (search "{" ann)) symbol)))
+    (format " %s [%s]" (substring ann 0 (cl-search "{" ann)) symbol)))
 
 ;; :nim-type is frequently way too big to display in meta
 ;; (defun company-nim-meta (cand)
@@ -147,8 +145,7 @@
     (doc-buffer (company-nim-doc-buffer arg))
     (meta (company-nim-meta arg))
     (location (company-nim-location arg))
-    (candidates (lexical-let ((local-arg arg))
-                  (cons :async (lambda (cb) (company-nim-candidates local-arg cb)))))
+    (candidates (cons :async (lambda (cb) (company-nim-candidates arg cb))))
     (ignore-case t)
     (sorted t)
     ))

--- a/nim-compile.el
+++ b/nim-compile.el
@@ -1,11 +1,10 @@
-;;; nim-compile.el ---
+;;; nim-compile.el --- -*- lexical-binding: t -*-
 
 ;;; Commentary:
 
 ;;
 
 ;;; Code:
-(eval-when-compile (require 'cl))
 (require 'nim-suggest)
 
 (defcustom nim-command "nim"
@@ -26,7 +25,7 @@ You don't need to set this if the nim executable is inside your PATH."
 
 (defun nim-compile (args &optional on-success)
   "Invoke the compiler and call ON-SUCCESS in case of successful compilation."
-  (lexical-let ((on-success (or on-success (lambda () (message "Compilation successful.")))))
+  (let ((on-success (or on-success (lambda () (message "Compilation successful.")))))
     (if (bufferp "*nim-compile*")
         (with-current-buffer "*nim-compile*"
           (erase-buffer)))))
@@ -51,13 +50,12 @@ success with the filename of the compiled file."
   (interactive)
   (save-buffer)
   (let ((default-directory (or (nim-get-project-root) default-directory)))
-    (lexical-let ((callback callback))
-      (nim-compile (list "js" (buffer-file-name))
-                      (lambda () (when callback
+    (nim-compile (list "js" (buffer-file-name))
+                 (lambda () (when callback
                               (funcall callback (concat default-directory
                                                         "nimcache/"
                                                         (file-name-sans-extension (file-name-nondirectory (buffer-file-name)))
-                                                        ".js"))))))))
+                                                        ".js")))))))
 
 (defun nim-compile-region-to-js (start end)
   "Compile the current region to javascript.
@@ -65,8 +63,8 @@ The result is written into the buffer
 `nim-compiled-buffer-name'."
   (interactive "r")
 
-  (lexical-let ((buffer (get-buffer-create nim-compiled-buffer-name))
-                (tmpdir (file-name-as-directory (make-temp-file "nim-compile" t))))
+  (let ((buffer (get-buffer-create nim-compiled-buffer-name))
+        (tmpdir (file-name-as-directory (make-temp-file "nim-compile" t))))
     (let ((default-directory tmpdir))
       (write-region start end "tmp.nim" nil 'foo)
       (with-current-buffer buffer

--- a/nim-fill.el
+++ b/nim-fill.el
@@ -1,4 +1,4 @@
-;;; nim-fill.el ---
+;;; nim-fill.el --- -*- lexical-binding: t -*-
 
 ;;; Commentary:
 

--- a/nim-helper.el
+++ b/nim-helper.el
@@ -1,4 +1,4 @@
-;;; nim-helper.el ---
+;;; nim-helper.el --- -*- lexical-binding: t -*-
 ;;; Commentary:
 ;; nim-nav-* and nim-info-* functions refer to each other, so they
 ;; can not split...

--- a/nim-indent.el
+++ b/nim-indent.el
@@ -1,4 +1,4 @@
-;;; nim-indent.el ---
+;;; nim-indent.el --- -*- lexical-binding: t -*-
 
 ;;; Commentary:
 

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -1,4 +1,4 @@
-;;; nim-mode.el --- A major mode for the Nim programming language
+;;; nim-mode.el --- A major mode for the Nim programming language -*- lexical-binding: t -*-
 ;;
 ;; Filename: nim-mode.el
 ;; Description: A major mode for the Nim programming language
@@ -45,8 +45,7 @@
 ;;
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 
 ;; Order of loading
 (require 'nim-vars)

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -1,4 +1,4 @@
-;;; nim-rx.el ---
+;;; nim-rx.el --- -*- lexical-binding: t -*-
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -1,4 +1,4 @@
-;;; nim-syntax.el ---
+;;; nim-syntax.el --- -*- lexical-binding: t -*-
 
 ;;
 ;; This program is free software; you can redistribute it and/or modify

--- a/nim-thing-at-point.el
+++ b/nim-thing-at-point.el
@@ -1,4 +1,4 @@
-;;; nim-thing-at-point.el --- 'thing-at-point' for nim-mode
+;;; nim-thing-at-point.el --- 'thing-at-point' for nim-mode -*- lexical-binding: t -*-
 ;;; Code:
 
 

--- a/nim-util.el
+++ b/nim-util.el
@@ -1,4 +1,4 @@
-;;; nim-util.el ---
+;;; nim-util.el --- -*- lexical-binding: t -*-
 ;;; Commentary:
 ;;
 ;;; Code:

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -1,4 +1,4 @@
-;;; nim-vars.el --- nim-mode's variables
+;;; nim-vars.el --- nim-mode's variables -*- lexical-binding: t -*-
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/tests/test-indent.el
+++ b/tests/test-indent.el
@@ -1,4 +1,9 @@
+;;; test-indent.el --- Tests for index -*-lexical-binding:t-*-
+
+;;; Code:
+
 (require 'nim-mode)
+(require 'cl-lib)
 
 (defun file-to-string (filename)
   (with-temp-buffer
@@ -8,8 +13,8 @@
 (describe
  "Indentation"
  (cl-defun indent-and-compare (test-string file-name &key (uncompleted-indent 4))
-   (lexical-let ((act (concat file-name "-actual.nim")) (exp (concat file-name "-expected.nim"))
-                 (indent uncompleted-indent))
+   (let ((act (concat file-name "-actual.nim")) (exp (concat file-name "-expected.nim"))
+         (indent uncompleted-indent))
      (it test-string
          (setq nim-uncompleted-condition-indent indent)
          (insert-file-contents-literally act)

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -1,4 +1,9 @@
+;;; test-syntax.el --- Tests for syntax.el -*-lexical-binding:t-*-
+
+;;; Code:
+
 (require 'nim-mode)
+(require 'cl-lib)
 
 (describe
  "Syntax"
@@ -17,25 +22,23 @@
      (concat test-syntax-dir filepath)))
 
  (defun test-faces (test-string file-name faces)
-   (lexical-let ((file-name file-name) (faces faces))
-     (it test-string
-         (insert-file-contents-literally file-name)
-         (font-lock-default-fontify-buffer)
-         (dolist (pos-face faces)
-           (expect
-            (get-text-property (car pos-face) 'face)
-            :to-equal
-            (cdr pos-face))))))
+   (it test-string
+       (insert-file-contents-literally file-name)
+       (font-lock-default-fontify-buffer)
+       (dolist (pos-face faces)
+         (expect
+          (get-text-property (car pos-face) 'face)
+          :to-equal
+          (cdr pos-face)))))
 
  (defun test-faces-by-range (test-string file-name spec &optional not)
-   (lexical-let ((file-name file-name) (spec spec) (not not))
-     (it test-string
+   (it test-string
        (insert-file-contents-literally file-name)
        (font-lock-default-fontify-buffer)
        (cl-loop for (place . expected-face) in spec
                 for start = (car place)
                 for end   = (cdr place)
-                do (test-helper-range-expect start end expected-face not)))))
+                do (test-helper-range-expect start end expected-face not))))
 
  (defun test-helper-range-expect (start end face &optional not)
    "Expect FACE between START and END positions."
@@ -47,45 +50,44 @@
                 face)))
 
  (defun test-characters (test-string file-name)
-   (lexical-let ((file-name file-name))
-     (it test-string
-         (insert-file-contents-literally file-name)
-         (font-lock-default-fontify-buffer)
-         (goto-char (point-min))
-         (search-forward "testCharacters: set[char] = {\n    ")
-         (let* ((limit (+ 128 22 128)) ; to prevent eternal loop
-                char-points
-                after-char-points
-                checked-characters)
-           (catch 'exit
-             (while (and (not (eql 0 limit)))
-               (setq limit (1- limit))
-               (re-search-forward
-                (rx (group "'" (regex "[^']\\{1,4\\}") "'")
-                    (group (or (1+ "," (or blank "\n"))
-                               (and "\n" (* blank) "}")))) nil t)
-               (let ((char       (match-string 1))
-                     (after-char (match-string 2)))
-                 (when char
-                   (let* ((start (- (point) (+ (length char) (length after-char))))
-                          (end (+ start (1- (length char)))))
-                     (push (cons start end) char-points)
-                     (push (substring-no-properties char) checked-characters)))
-                 (when after-char
-                   (let* ((start2 (- (point) (length after-char)))
-                          (end2 (1- (point))))
-                     (push (cons start2 end2) after-char-points)))
-                 (when (string-match "\\XFF" char)
-                   (throw 'exit nil)))))
-           (when char-points
-             (cl-loop for (s . e) in char-points
-                      do (test-helper-range-expect s e 'font-lock-string-face)))
-           (when after-char-points
-             (cl-loop for (s . e) in after-char-points
-                      do (test-helper-range-expect s e 'font-lock-string-face t)))
-           ;; You can check what you checked
-           ;; (print (reverse checked-characters))
-           ))))
+   (it test-string
+       (insert-file-contents-literally file-name)
+       (font-lock-default-fontify-buffer)
+       (goto-char (point-min))
+       (search-forward "testCharacters: set[char] = {\n    ")
+       (let* ((limit (+ 128 22 128))    ; to prevent eternal loop
+              char-points
+              after-char-points
+              checked-characters)
+         (catch 'exit
+           (while (and (not (eql 0 limit)))
+             (setq limit (1- limit))
+             (re-search-forward
+              (rx (group "'" (regex "[^']\\{1,4\\}") "'")
+                  (group (or (1+ "," (or blank "\n"))
+                             (and "\n" (* blank) "}")))) nil t)
+             (let ((char       (match-string 1))
+                   (after-char (match-string 2)))
+               (when char
+                 (let* ((start (- (point) (+ (length char) (length after-char))))
+                        (end (+ start (1- (length char)))))
+                   (push (cons start end) char-points)
+                   (push (substring-no-properties char) checked-characters)))
+               (when after-char
+                 (let* ((start2 (- (point) (length after-char)))
+                        (end2 (1- (point))))
+                   (push (cons start2 end2) after-char-points)))
+               (when (string-match "\\XFF" char)
+                 (throw 'exit nil)))))
+         (when char-points
+           (cl-loop for (s . e) in char-points
+                    do (test-helper-range-expect s e 'font-lock-string-face)))
+         (when after-char-points
+           (cl-loop for (s . e) in after-char-points
+                    do (test-helper-range-expect s e 'font-lock-string-face t)))
+         ;; You can check what you checked
+         ;; (print (reverse checked-characters))
+         )))
 
  (defun test-double-quote-and-next-line (test-string file-name start-strings)
    (lexical-let ((file-name file-name)


### PR DESCRIPTION
- Use cl-lib functions/macros instead of cl.el
- Enable lexical-binding at all files. This package supports Emacs 24 or higher, so it is no problems.
- Remove lexical-let.