### PR TITLE
Improve syntax highlight (including #51)

### DIFF
--- a/nim-rx.el
+++ b/nim-rx.el
@@ -140,9 +140,17 @@ This variant of `rx' supports common nim named REGEXPS."
             (t
              (rx-to-string (car regexps) t)))))
 
+  ;; based on nim manual
+  (add-to-list 'nim-rx-constituents
+               ;; note rx.el already has ‘letter’
+               (cons 'nim-letter (rx (in "a-zA-Z-ÿ"))))
+
+  (add-to-list 'nim-rx-constituents
+               (cons 'identifier (nim-rx nim-letter
+                                         (0+ (or "_" nim-letter digit)))))
+
   (add-to-list 'nim-rx-constituents
                (cons 'block-start (nim-rx (or decl-block block-start-defun))))
-
   ;; Regular expression matching the end of line after with a block starts.
   ;; If the end of a line matches this regular expression, the next
   ;; line is considered an indented block.  Whitespaces at the end of a

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -150,6 +150,16 @@ This variant of `rx' supports common nim named REGEXPS."
                                          (0+ (or "_" nim-letter digit)))))
 
   (add-to-list 'nim-rx-constituents
+               (cons 'quoted-chars
+                     (nim-rx
+                      (and "`"
+                           (or
+                            identifier
+                            (1+ (or "^" "*" "[" "]" "!" "$" "%" "&"  "+" "-" "."
+                                    "/" "<" "=" ">" "?" "@" "|" "~")))
+                           "`"))))
+
+  (add-to-list 'nim-rx-constituents
                (cons 'block-start (nim-rx (or decl-block block-start-defun))))
   ;; Regular expression matching the end of line after with a block starts.
   ;; If the end of a line matches this regular expression, the next

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -25,8 +25,7 @@
 (eval-and-compile (require 'nim-rx))
 
 (defconst nim-font-lock-keywords
-  `(;; note the BACKTICK, `
-    ;; (,(nim-rx (1+ "\t")) . nim-tab-face) ;; TODO: make work!
+  `((,(nim-rx (1+ "\t")) . 'nim-tab-face)
     (,(nim-rx defun (1+ whitespace) (group symbol-name))
      . (1 font-lock-function-name-face))
     (,(nim-rx (or "var" "let") (1+ whitespace) (group symbol-name))

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -32,8 +32,12 @@
      . (1 (if (match-string 2)
               'nim-font-lock-export-face
             font-lock-function-name-face)))
-    (,(nim-rx (or "var" "let" "const") (1+ " ") (group symbol-name))
-     . (1 font-lock-variable-name-face))
+    ;; This only works if it’s one line
+    (,(nim-rx (or "var" "let" "const") (1+ " ")
+              (group (or identifier quoted-chars) (? " ") (? (group "*"))))
+     . (1 (if (match-string 2)
+              'nim-font-lock-export-face
+            font-lock-variable-name-face)))
     (,(nim-rx (or exception type)) . font-lock-type-face)
     (,(nim-rx constant) . font-lock-constant-face)
     (,(nim-rx builtin) . font-lock-builtin-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -53,7 +53,8 @@
     (,(nim-rx builtin) . font-lock-builtin-face)
     (,(nim-rx keyword) . font-lock-keyword-face)
     (,(nim-rx "{." (1+ any) ".}") . font-lock-preprocessor-face)
-    (,(nim-rx symbol-name (* " ") ":" (* " ") (group symbol-name))
+    (,(nim-rx (or identifier quoted-chars) (? "*")
+              (* " ") ":" (* " ") (group identifier))
      . (1 font-lock-type-face)))
   "Font lock expressions for Nim mode.")
 

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -38,6 +38,16 @@
      . (1 (if (match-string 2)
               'nim-font-lock-export-face
             font-lock-variable-name-face)))
+    ;; For multiple line properties
+    (,(nim-rx line-start (1+ " ")
+              (group
+               (or identifier quoted-chars) "*"
+               (? (and "[" word "]"))
+               (0+ (and "," (? (0+ " "))
+                        (or identifier quoted-chars) "*")))
+              (0+ " ") (or ":" "{." "=") (0+ nonl)
+              line-end)
+     . (1 'nim-font-lock-export-face))
     (,(nim-rx (or exception type)) . font-lock-type-face)
     (,(nim-rx constant) . font-lock-constant-face)
     (,(nim-rx builtin) . font-lock-builtin-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -26,8 +26,12 @@
 
 (defconst nim-font-lock-keywords
   `((,(nim-rx (1+ "\t")) . 'nim-tab-face)
-    (,(nim-rx defun (1+ " ") (group symbol-name))
-     . (1 font-lock-function-name-face))
+    (,(nim-rx defun (1+ " ")
+              (group (or identifier quoted-chars)
+                     (0+ " ") (? (group "*"))))
+     . (1 (if (match-string 2)
+              'nim-font-lock-export-face
+            font-lock-function-name-face)))
     (,(nim-rx (or "var" "let") (1+ " ") (group symbol-name))
      . (1 font-lock-variable-name-face))
     (,(nim-rx (or exception type)) . font-lock-type-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -32,7 +32,7 @@
      . (1 (if (match-string 2)
               'nim-font-lock-export-face
             font-lock-function-name-face)))
-    (,(nim-rx (or "var" "let") (1+ " ") (group symbol-name))
+    (,(nim-rx (or "var" "let" "const") (1+ " ") (group symbol-name))
      . (1 font-lock-variable-name-face))
     (,(nim-rx (or exception type)) . font-lock-type-face)
     (,(nim-rx constant) . font-lock-constant-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -26,16 +26,16 @@
 
 (defconst nim-font-lock-keywords
   `((,(nim-rx (1+ "\t")) . 'nim-tab-face)
-    (,(nim-rx defun (1+ whitespace) (group symbol-name))
+    (,(nim-rx defun (1+ " ") (group symbol-name))
      . (1 font-lock-function-name-face))
-    (,(nim-rx (or "var" "let") (1+ whitespace) (group symbol-name))
+    (,(nim-rx (or "var" "let") (1+ " ") (group symbol-name))
      . (1 font-lock-variable-name-face))
     (,(nim-rx (or exception type)) . font-lock-type-face)
     (,(nim-rx constant) . font-lock-constant-face)
     (,(nim-rx builtin) . font-lock-builtin-face)
     (,(nim-rx keyword) . font-lock-keyword-face)
     (,(nim-rx "{." (1+ any) ".}") . font-lock-preprocessor-face)
-    (,(nim-rx symbol-name (* whitespace) ":" (* whitespace) (group symbol-name))
+    (,(nim-rx symbol-name (* " ") ":" (* " ") (group symbol-name))
      . (1 font-lock-type-face)))
   "Font lock expressions for Nim mode.")
 

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -33,7 +33,7 @@
               'nim-font-lock-export-face
             font-lock-function-name-face)))
     ;; This only works if it’s one line
-    (,(nim-rx (or "var" "let" "const") (1+ " ")
+    (,(nim-rx (or "var" "let" "const" "type") (1+ " ")
               (group (or identifier quoted-chars) (? " ") (? (group "*"))))
      . (1 (if (match-string 2)
               'nim-font-lock-export-face

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -148,15 +148,17 @@ The above string is taken from URL
 updating.")
 
 (defconst nim-types
-  '("int" "int8" "int16" "int32" "int64" "float" "float32" "float64"
-    "bool" "char" "string" "cstring" "pointer" "ordinal" "nil" "expr"
-    "stmt" "typedesc" "range" "array" "openarray" "seq" "set"
-    "tgenericseq" "pgenericseq" "nimstringdesc" "nimstring" "byte"
-    "natural" "positive" "tobject" "pobject" "tresult" "tendian"
-    "taddress" "biggestint" "biggestfloat" "cchar" "cschar" "cshort"
-    "cint" "clong" "clonglong" "cfloat" "cdouble" "clongdouble"
+  '("int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16" "uint32"
+    "uint64" "float" "float32" "float64" "bool" "char" "string" "cstring"
+    "pointer" "ordinal" "nil" "expr" "stmt" "typedesc" "void" "auto" "any"
+    "untyped" "typed" "range" "array" "openarray" "Ordinal" "seq" "set"
+    "tgenericseq" "pgenericseq" "nimstringdesc" "nimstring" "byte" "natural"
+    "positive" "tobject" "pobject"
+    "tresult" "tendian" "taddress" "biggestint" "biggestfloat" "cchar" "cschar"
+    "cshort" "cint" "clong" "clonglong" "cfloat" "cdouble" "clongdouble"
     "cstringarray" "pfloat32" "pfloat64" "pint64" "pint32"
-    "tgc_strategy" "tfile" "tfilemode")
+    "SomeSignedInt" "SomeUnsignedInt" "SomeInteger" "SomeOrdinal" "SomeReal"
+    "SomeNumber" "tgc_strategy" "tfile" "tfilemode")
   "Nim types defined in <lib/system.nim>.")
 
 (defconst nim-exceptions
@@ -174,7 +176,8 @@ updating.")
   '("ismainmodule" "compiledate" "compiletime" "nimversion"
     "nimmajor" "nimminor" "nimpatch" "cpuendian" "hostos"
     "hostcpu" "apptype" "inf" "neginf" "nan" "quitsuccess"
-    "quitfailure" "stdin" "stdout" "stderr" "true" "false" )
+    "quitfailure" "stdin" "stdout" "stderr" "true" "false"
+    "on" "off")
   "Nim constants defined in <lib/system.nim>.")
 
 (defconst nim-builtins

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -45,7 +45,6 @@
   :type 'assoc
   :group 'nim)
 
-;; TODO: make work!?
 (defface nim-tab-face
   '((((class color) (background dark))
      (:background "grey22" :foreground "darkgray"))

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -55,6 +55,13 @@
   "Face used to visualize TAB."
   :group 'nim)
 
+(defface nim-font-lock-export-face
+  '((t :weight bold
+       :slant italic
+       :inherit font-lock-function-name-face))
+  "Font Lock face for export (XXX*)"
+  :group 'nim)
+
 (defconst nim-indent-offset 2 "Number of spaces per level of indentation.")
 
 (defcustom nim-smie-function-indent 4

--- a/tests/syntax/export.nim
+++ b/tests/syntax/export.nim
@@ -1,0 +1,7 @@
+var single_line*:string = "foo"
+
+let
+  multi_line*:string = "foo"
+  multi_line2*:string = "foo"
+
+proc foo*() = echo "foo"

--- a/tests/syntax/function_name.nim
+++ b/tests/syntax/function_name.nim
@@ -1,0 +1,2 @@
+proc foo(): string =
+  "string"

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -129,6 +129,11 @@
     ((69  . 80)  . nim-font-lock-export-face)
     ((103 . 106) . nim-font-lock-export-face)))
 
+ (test-faces-by-range
+  "should highlight function name"
+  (test-concat-dir "tests/syntax/function_name.nim")
+  '(((6   . 8)  . font-lock-function-name-face)))
+
  (test-double-quote-and-next-line
   "should highlight double quoted string with single quotes"
   ;; This test makes sure whether highlights after "xxx = " are

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -170,3 +170,9 @@
     ((128 . 176) . font-lock-doc-face)))
 
  ) ; end of describe function
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+;;; test-syntax.el ends here

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -121,6 +121,14 @@
   (test-concat-dir "tests/syntax/string.nim")
   '(((33 . 86) . font-lock-string-face)))
 
+ (test-faces-by-range
+  "should highlight export variables"
+  (test-concat-dir "tests/syntax/export.nim")
+  '(((5   . 16)  . nim-font-lock-export-face)
+    ((40  . 50)  . nim-font-lock-export-face)
+    ((69  . 80)  . nim-font-lock-export-face)
+    ((103 . 106) . nim-font-lock-export-face)))
+
  (test-double-quote-and-next-line
   "should highlight double quoted string with single quotes"
   ;; This test makes sure whether highlights after "xxx = " are


### PR DESCRIPTION
Added features highlighting tabs, exports(like XXX*,  probably same as #51), and
some essential types (from system.nim)