### PR TITLE
Multiline comment

### DIFF
--- a/nim-helper.el
+++ b/nim-helper.el
@@ -919,7 +919,8 @@ When optional argument SYNTAX-PPSS is given, use that instead of
 point's current `syntax-ppss'."
   (let ((ppss (or syntax-ppss (syntax-ppss))))
     (and (eq ?# (char-before (1+  (nth 8 ppss))))
-         (eq ?# (char-before (+ 2 (nth 8 ppss)))))))
+         (eq ?# (char-before (+ 2 (nth 8 ppss))))
+         (not (eq ?# (char-before (+ 3 (nth 8 ppss))))))))
 
 (defun nim-line-contain-p (char &optional pos backward)
   "Return non-nil if the current line has CHAR.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -80,7 +80,7 @@
 
   ;; Comment
   (setq-local comment-start "# ")
-  (setq-local comment-start-skip "#+\\s-*")
+  (setq-local comment-start-skip (rx (1+ "#") (? "[") (0+ " ")))
 
   ;; SMIE
   (smie-setup nim-mode-smie-grammar 'nim-mode-smie-rules

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -157,13 +157,6 @@ If it’s nil, it does nothing."
     (modify-syntax-entry ?\} "){  " table)
     (modify-syntax-entry ?\( "()  " table)
     (modify-syntax-entry ?\) ")(  " table)
-
-    ;; ;; Documentation comment highlighting
-    ;; ;; (modify-syntax-entry ?\# ". 12b" nim-mode-syntax-table)
-    ;; ;; (modify-syntax-entry ?\n "> b" nim-mode-syntax-table)
-    ;; ;; Comment highlighting
-    ;; (modify-syntax-entry ?# "< b"  nim-mode-syntax-table)
-    ;; (modify-syntax-entry ?\n "> b" nim-mode-syntax-table)
     table)
   "Syntax table for Nim files.")
 

--- a/tests/syntax/multiline_comment.nim
+++ b/tests/syntax/multiline_comment.nim
@@ -1,0 +1,25 @@
+###[ <- this is treated as single comment
+echo "#[]# is multi line comment"
+#[
+bla bla bla bla bla bla
+# inside hash
+#[nesting comment]#
+##[nesting comment]##
+bla bla bla bla bla bla
+]#
+echo "##[]## is multi line documentation comment"
+##[
+multi line documentation comment can include
+#[nesting]# and #[nesting] (unbalance #[ is ok)
+
+Also nested docummentation comment: ##[ nested doc comment ]##
+(, but need to provide both open ##[ and close ]## )
+]##
+
+proc testMultiComment =
+  ##[ multi line comment test
+  aaa #[nesting]# bbb
+  ]##
+  echo "foo bar"
+
+var foo #[ comment ]#: string = "foo"

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -188,6 +188,21 @@
   '(((56 . 100)  . font-lock-doc-face)
     ((128 . 176) . font-lock-doc-face)))
 
+ ;; multi line comment or doc comment
+  (test-faces-by-range
+   "should highlight multi line comment and doc string"
+   (test-concat-dir "tests/syntax/multiline_comment.nim")
+   '(((1 . 5) . font-lock-comment-delimiter-face)
+     ((48 . 75)  . font-lock-string-face)
+     ((77 . 78) . font-lock-comment-delimiter-face)
+     ((80 . 185)  . font-lock-comment-face)
+     ((192 . 235)  . font-lock-string-face)
+     ((237 . 453)  . font-lock-doc-face)
+     ((482 . 536)  . font-lock-doc-face)
+     ((545 . 553)  . font-lock-string-face)
+     ((564 . 566)  . font-lock-comment-face)
+     ((567 . 576)  . font-lock-comment-delimiter-face)))
+
  ) ; end of describe function
 
 ;; Local Variables:


### PR DESCRIPTION
This PR enables highlighting multiline comment (#[]# and ##[]##)
The test is based on /tests/parser/tmultiline_comments.nim at devel branch.