### PR TITLE
Add nim-indent-line function to Elctric indent's block list #54

### DIFF
--- a/nim-fill.el
+++ b/nim-fill.el
@@ -236,7 +236,7 @@ JUSTIFY should be used (if applicable) as in `fill-paragraph'."
       (fill-paragraph justify))
     (while (not (eobp))
       (forward-line 1)
-      (nim-indent-line)
+      (nim--indent-line-core)
       (goto-char (line-end-position))))
   t)
 

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -102,9 +102,6 @@
   ;; Syntax highlight for strings
   (setq-local syntax-propertize-function nim-syntax-propertize-function)
 
-  ;; Because indentation is not redundant, we cannot safely reindent code.
-  (setq-local electric-indent-inhibit t)
-  (setq-local electric-indent-chars (cons ?: electric-indent-chars))
   ;; Paragraph
   (setq-local paragraph-start "\\s-*$")
   ;; Navigation
@@ -121,7 +118,11 @@
             #'nim-electric-pair-string-delimiter 'append t)
   (add-hook 'post-self-insert-hook
             #'nim-indent-post-self-insert-function 'append 'local)
-  (add-hook 'which-func-functions #'nim-info-current-defun nil t))
+  (add-hook 'which-func-functions #'nim-info-current-defun nil t)
+
+  ;; Because indentation is not redundant, we cannot safely reindent code.
+  (setq-local electric-indent-inhibit t)
+  (setq-local electric-indent-chars (cons ?: electric-indent-chars)))
 
 ;; add ‘nim-indent-function’ to electric-indent’s
 ;; blocklist. ‘electric-indent-inhibit’ isn’t enough for old emacs.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -86,7 +86,7 @@
   (smie-setup nim-mode-smie-grammar 'nim-mode-smie-rules
               :forward-token 'nim-mode-forward-token
               :backward-token 'nim-mode-backward-token)
-  (setq-local indent-line-function #'nim-indent-line-function)
+  (setq-local indent-line-function #'nim-indent-line)
   ;; FIXME: due to uncompleted Nim’s smie grammar,
   ;; ‘smie--matching-block-data’ function gets stop when
   ;; the cursor is at proc/template/macro to find terminator

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -170,7 +170,7 @@ the line will be re-indented automatically if needed."
         (when dedenter-pos
           (save-excursion
             (goto-char dedenter-pos)
-            (nim-indent-line)
+            (nim--indent-line-core)
             (unless (= (line-number-at-pos dedenter-pos)
                        (line-number-at-pos current-pos))
               ;; Reindent region if this is a multiline statement

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -123,6 +123,10 @@
             #'nim-indent-post-self-insert-function 'append 'local)
   (add-hook 'which-func-functions #'nim-info-current-defun nil t))
 
+;; add ‘nim-indent-function’ to electric-indent’s
+;; blocklist. ‘electric-indent-inhibit’ isn’t enough for old emacs.
+(add-to-list 'electric-indent-functions-without-reindent 'nim-indent-line)
+
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.nim\\(ble\\|s\\)?\\'" . nim-mode))
 

--- a/nim-smie.el
+++ b/nim-smie.el
@@ -821,7 +821,7 @@ This works if only current line starts from comment."
         (nth 8 ppss))))
 
 (defun nim--indent-line-core (&optional previous)
-  "Internal implementation of `nim-indent-line-function'.
+  "Internal implementation of `nim-indent-line'.
 Use the PREVIOUS level when argument is non-nil, otherwise indent
 to the maximum available level.  When indentation is the minimum
 possible and PREVIOUS is non-nil, cycle back to the maximum
@@ -840,7 +840,7 @@ level."
     (when follow-indentation-p
       (back-to-indentation))))
 
-(defun nim-indent-line-function ()
+(defun nim-indent-line ()
   "`indent-line-function' for Nim mode.
 When the variable `last-command' is equal to one of the symbols
 inside `nim-indent-trigger-commands' it cycles possible

--- a/nim-smie.el
+++ b/nim-smie.el
@@ -820,7 +820,7 @@ This works if only current line starts from comment."
       (when (eq t (nth 4 ppss))
         (nth 8 ppss))))
 
-(defun nim-indent-line (&optional previous)
+(defun nim--indent-line-core (&optional previous)
   "Internal implementation of `nim-indent-line-function'.
 Use the PREVIOUS level when argument is non-nil, otherwise indent
 to the maximum available level.  When indentation is the minimum
@@ -845,7 +845,7 @@ level."
 When the variable `last-command' is equal to one of the symbols
 inside `nim-indent-trigger-commands' it cycles possible
 indentation levels from right to left."
-  (nim-indent-line
+  (nim--indent-line-core
    (and (memq this-command nim-indent-trigger-commands)
         (eq last-command this-command))))
 

--- a/nim-util.el
+++ b/nim-util.el
@@ -207,7 +207,5 @@ returned as is."
              (eq (char-after) last-command-event))
     (save-excursion (insert (make-string 2 last-command-event)))))
 
-(defvar electric-indent-inhibit)
-
 (provide 'nim-util)
 ;;; nim-util.el ends here


### PR DESCRIPTION
I noticed `electric-indent-inhibit` isn't enough for specific emacs 24.4 from this 
discussion: https://github.com/haskell/haskell-mode/issues/377

So, I added `nim-indent-line` function to `electric-indent-functions-without-reindent`, 
which is block list for electric-indent. I hope this PR solve #54 as well.
