### PR TITLE
Apply multi line comment/uncomment region functions

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,5 +7,6 @@
  (depends-on "buttercup")
  (depends-on "epc")
  (depends-on "company")
+ (depends-on "commenter")
  (depends-on "let-alist")
  (depends-on "cl-lib"))

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ If you use `auto-indent-mode` you need to add nim-mode to the list of `auto-inde
 ```el
 (add-to-list 'auto-indent-multiple-indent-modes 'nim-mode)
 ```
+
+## Commenting
+nim-mode refers to `comment-style` variable which comment style user
+preferred (whether single line or multi line comment) when user invokes
+`comment-region` or `comment-dwim`. See also `comment-styles` variable
+for available options.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -7,7 +7,7 @@
 ;; Version: 0.2.0
 ;; Keywords: nim languages
 ;; Compatibility: GNU Emacs 24.4
-;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1"))
+;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1"))
 ;;
 ;; Taken over from James H. Fisher <jameshfisher@gmail.com>
 ;;

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -56,6 +56,7 @@
 (require 'nim-fill)
 (require 'nim-suggest)
 (require 'nim-compile)
+(require 'commenter)
 
 (put 'nim-mode 'font-lock-defaults '(nim-font-lock-keywords nil t))
 
@@ -79,9 +80,13 @@
                  . nim-font-lock-syntactic-face-function)))
 
   ;; Comment
-  (setq-local comment-start "# ")
-  (setq-local comment-start-skip (rx (1+ "#") (? "[") (0+ " ")))
   (setq-local comment-use-syntax t)
+  ;; Those start and end comment variables are for initial value.
+  (setq-local comment-start "#")
+  (setq-local comment-end "")
+  ;; actual comment values are defined here
+  (setq-local commenter-config nim-comment)
+  (commenter-setup)
 
   ;; SMIE
   (smie-setup nim-mode-smie-grammar 'nim-mode-smie-rules

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -81,6 +81,7 @@
   ;; Comment
   (setq-local comment-start "# ")
   (setq-local comment-start-skip (rx (1+ "#") (? "[") (0+ " ")))
+  (setq-local comment-use-syntax t)
 
   ;; SMIE
   (smie-setup nim-mode-smie-grammar 'nim-mode-smie-rules

--- a/nim-smie.el
+++ b/nim-smie.el
@@ -780,7 +780,8 @@ See also ‘smie-rules-function’ about KIND and TOKEN."
       (goto-char (point-at-bol))
       (forward-comment (- (point)))
       (when (< (line-number-at-pos) start-line)
-        (member (char-to-string (char-before (point))) strings)))))
+        (let ((c (char-before (point))))
+          (when c (member (char-to-string c) strings)))))))
 
 (defun nim-get-comment-indent ()
   "Return indent number for comment.

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -146,9 +146,8 @@ other tokens like ’:’ or ’=’."
     (modify-syntax-entry ?$ "." table)
     (modify-syntax-entry ?% "." table)
 
-    ;; Comment start
-    (modify-syntax-entry ?# "<" table)
-    ;; Comment end
+    ;; Comment
+    (modify-syntax-entry ?# "." table)
     (modify-syntax-entry ?\n ">" table)
     ;; Use "." Punctuation syntax class because I got error when I
     ;; used "$" from smie.el

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -175,6 +175,28 @@ other tokens like ’:’ or ’=’."
   "Dotty syntax table for Nim files.
 It makes underscores and dots word constituent chars.")
 
+(defconst nim-comment
+  `((single
+     . ((comment-start      . "#")
+        (comment-end        . "")
+        (comment-start-skip . ,(rx "#" (? "#") (? " ")))
+        (comment-use-syntax . t)))
+    (multi
+     . ((comment-start      . "#[")
+        (comment-end        . "]#")
+        (comment-start-skip
+         . ,(rx (group
+                 (syntax comment-start) (? "#") "[")))
+        (comment-end-skip
+         . ,(rx (group
+                 "]#" (? "#"))))
+        ;; comment-continue has to include non space character
+        ;; otherwise it makes trouble when you do ‘uncomment-region’.
+        (comment-continue   . " |")
+        (comment-padding    . "  ")
+        (comment-multi-line . t)
+        (comment-use-syntax . nil)))))
+
 (defconst nim-keywords
   '("addr" "and" "as" "asm" "atomic" "bind" "block" "break" "case"
     "cast" "const" "continue" "converter" "discard" "distinct" "div" "do"


### PR DESCRIPTION
In multi-line comment, comment-region and uncomment-region functions didn't work
correctly.