### PR TITLE
Improve highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,25 @@ An emacs major mode for the Nim programming language.
 * Install `nim-mode.el` via MELPA.
 
 ## Nimsuggest
-Some packages are depending on [nimsuggest](https://github.com/nim-lang/nimsuggest) (not nim-suggest.el), so if you want to use more integration in Emacs, please visit the link to install nimsuggest.
+In nim-mode repository, some *.el files depend on
+[nimsuggest](https://github.com/nim-lang/nimsuggest) (not
+nim-suggest.el), so if you want to use more integration in Emacs,
+please visit the link to install nimsuggest.
 
-Brief descriptions for nimsuggest related packages:
+Brief descriptions for the nimsuggest related files:
   1. nim-company.el: auto completion feature
   2. nim-thing-at-point.el: thing-at-point for nim
   3. nim-eldoc: show information in minibuffer
 
 After you install nimsuggest, you may need following configuration.
 
-```lisp
-;; If you register nimsuggest to PATH, you don't need this
-;; configuration.
+```el
 (setq nim-nimsuggest-path "path/to/nimsuggest")
 ```
+
+Note that above `nim-nimsuggest-path` variable is automatically set
+result of `(executable-find "nimsuggest")`, so if you can get value from
+ the `executable-find`, you might don't need above configuration.
 
 ## company-mode
 If you use `company-mode` then add `company-nim` to `company-backends` like:
@@ -34,7 +39,8 @@ If you use `company-mode` then add `company-nim` to `company-backends` like:
 This feature is automatically turned on if `nim-suggest-path` is non-nil.
 
 ## auto-indent mode
-If you use `auto-indent-mode` you need to add nim-mode to the list of `auto-indent-multiple-indent-modes`:
+If you use `auto-indent-mode`, you need to add nim-mode to the list of
+`auto-indent-multiple-indent-modes`:
 ```el
 (add-to-list 'auto-indent-multiple-indent-modes 'nim-mode)
 ```
@@ -44,3 +50,7 @@ nim-mode refers to `comment-style` variable which comment style user
 preferred (whether single line or multi line comment) when user invokes
 `comment-region` or `comment-dwim`. See also `comment-styles` variable
 for available options.
+
+## Other convenience packages
+- [flycheck-nim](https://github.com/ALSchwalm/flycheck-nim)
+- [indent-guide](https://github.com/zk-phi/indent-guide)

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -72,6 +72,10 @@
 (define-derived-mode nim-mode prog-mode "Nim"
   "A major mode for the Nim programming language."
   :group 'nim
+
+  ;; init hook
+  (run-hooks nim-mode-init-hook)
+
   ;; Font lock
   (setq-local font-lock-defaults
               `(,(append nim-font-lock-keywords

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -75,6 +75,7 @@
   ;; Font lock
   (setq-local font-lock-defaults
               `(,(append nim-font-lock-keywords
+                         nim-font-lock-keywords-extra
                          nim-font-lock-keywords-2)
                 nil nil nil nil
                 (font-lock-syntactic-face-function

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -74,7 +74,8 @@
   :group 'nim
   ;; Font lock
   (setq-local font-lock-defaults
-              '(nim-font-lock-keywords
+              `(,(append nim-font-lock-keywords
+                         nim-font-lock-keywords-2)
                 nil nil nil nil
                 (font-lock-syntactic-face-function
                  . nim-font-lock-syntactic-face-function)))

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -166,6 +166,19 @@ This variant of `rx' supports common nim named REGEXPS."
   (add-to-list 'nim-rx-constituents
                (cons 'block-start (nim-rx (or decl-block block-start-defun))))
 
+  (add-to-list 'nim-rx-constituents
+               (cons 'font-lock-defun
+                     (nim-rx defun
+                             (? (group (1+ " ") (or identifier quoted-chars)
+                                       (0+ " ") (? (group "*"))))
+                             (? (minimal-match
+                                 (group (0+ " ") "[" (0+ (or any "\n")) "]")))
+                             (? (minimal-match
+                                 (group (0+ " ") "(" (0+ (or any "\n")) ")")))
+                             (? (group (0+ " ") ":" (0+ " ")
+                                       (? (group (or "ref" "ptr") " " (* " ")))
+                                       (group identifier))))))
+
   ) ; end of eval-and-compile
 
 (provide 'nim-rx)

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -208,6 +208,29 @@ This variant of `rx' supports common nim named REGEXPS."
                              (group identifier))))
 
   (add-to-list 'nim-rx-constituents
+               (cons 'backquoted-chars
+                     (rx
+                      (syntax expression-prefix)
+                      (minimal-match (1+ (not (syntax comment-end))))
+                      (syntax expression-prefix))))
+
+  (add-to-list 'nim-rx-constituents
+               (cons 'backticks
+                     (nim-rx
+                      (or line-start " " (syntax open-parenthesis))
+                      (group (or (group (syntax expression-prefix)
+                                        backquoted-chars
+                                        (syntax expression-prefix))
+                                 (group backquoted-chars)))
+                      (or " "
+                          line-end
+                          (syntax punctuation)
+                          (syntax comment-end)
+                          (syntax symbol)
+                          (syntax open-parenthesis)
+                          (syntax close-parenthesis)))))
+
+  (add-to-list 'nim-rx-constituents
                (cons 'font-lock-export
                      (nim-rx line-start (1+ " ")
                              (group

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -207,6 +207,17 @@ This variant of `rx' supports common nim named REGEXPS."
                              (? (group (and (or "ref" "ptr") " " (* " "))))
                              (group identifier))))
 
+  (add-to-list 'nim-rx-constituents
+               (cons 'font-lock-export
+                     (nim-rx line-start (1+ " ")
+                             (group
+                              (or identifier quoted-chars) "*"
+                              (? (and "[" word "]"))
+                              (0+ (and "," (? (0+ " "))
+                                       (or identifier quoted-chars) "*")))
+                             (0+ " ") (or ":" "{." "=") (0+ nonl)
+                             line-end)))
+
   ) ; end of eval-and-compile
 
 (provide 'nim-rx)

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -195,7 +195,9 @@ This variant of `rx' supports common nim named REGEXPS."
                                  (group (0+ " ") "[" (0+ (or any "\n")) "]")))
                              (? (minimal-match
                                  (group (0+ " ") "(" (0+ (or any "\n")) ")")))
+                             ;; return type
                              (? (group (0+ " ") ":" (0+ " ")
+                                       (? (group "var " (0+ " ")))
                                        (? (group (or "ref" "ptr") " " (* " ")))
                                        (group identifier))))))
 

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -179,6 +179,14 @@ This variant of `rx' supports common nim named REGEXPS."
                                        (? (group (or "ref" "ptr") " " (* " ")))
                                        (group identifier))))))
 
+  (add-to-list 'nim-rx-constituents
+               (cons 'colon-type
+                     (nim-rx (or identifier quoted-chars) (? "*")
+                             (* " ") ":" (* " ")
+                             (? (and "var " (0+ " ")))
+                             (? (group (and (or "ref" "ptr") " " (* " "))))
+                             (group identifier))))
+
   ) ; end of eval-and-compile
 
 (provide 'nim-rx)

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -149,6 +149,26 @@ This variant of `rx' supports common nim named REGEXPS."
                      (nim-rx
                       (group (or (and (in "fF") (or "32" "64" "128")) (in "dD"))))))
 
+  (add-to-list 'nim-rx-constituents
+               (cons 'nim-numbers
+                     (nim-rx
+                      symbol-start
+                      (or
+                       ;; float hex
+                       (group (group hex-lit)
+                              ;; "'" isn’t optional
+                              (group "'" float-suffix))
+                       ;; float
+                       (group (group (or float-lit dec-lit oct-lit bin-lit))
+                              (group (? "'") float-suffix))
+                       ;; u?int
+                       (group
+                        (group int-lit)
+                        (? (group (? "'")
+                                  (or (and (in "uUiI") (or "8" "16" "32" "64"))
+                                      (in "uU"))))))
+                      symbol-end)))
+
   ;; pragma
   (add-to-list
    'nim-rx-constituents

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -31,7 +31,7 @@
             'nim-font-lock-export-face
           font-lock-function-name-face)
         keep t)
-     (7 font-lock-type-face keep t))
+     (8 font-lock-type-face keep t))
     ;; Highlight type words
     (nim-type-matcher
      (1 font-lock-keyword-face keep t)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -47,6 +47,9 @@
     ;; Number literal
     (nim-number-matcher
      (0 'nim-font-lock-number-face))
+    ;; Highlight ``identifier``
+    (nim-backtick-matcher
+     (1 font-lock-constant-face prepend))
     ;; other keywords
     (,(nim-rx (or exception type)) . font-lock-type-face)
     (,(nim-rx constant) . font-lock-constant-face)
@@ -241,6 +244,16 @@ character address of the specified TYPE."
   (forward-comment (point-max))
   (when (nth 3 (save-excursion (syntax-ppss)))
     (re-search-forward "\\s|" nil t)))
+
+(defun nim-backtick-matcher (&optional _start-pos)
+  "Highlight matcher for ``symbol`` in comment."
+  (nim-matcher-func
+   (lambda ()
+     (unless (nth 4 (save-excursion (syntax-ppss)))
+       (re-search-forward "\\s<" nil t)))
+   (lambda ()
+     (not (re-search-forward (nim-rx backticks) nil t)))
+   (lambda (ppss) (not (nth 4 ppss)))))
 
 
 (defun nim-pragma-matcher (&optional _start-pos)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -52,16 +52,16 @@
      (1 font-lock-constant-face prepend))
     ;; Highlight $# and $[0-9]+ inside string
     (nim-format-$-matcher . (1 font-lock-preprocessor-face prepend))
-    ;; other keywords
-    (,(nim-rx (or exception type)) . font-lock-type-face)
-    (,(nim-rx constant) . font-lock-constant-face)
-    (,(nim-rx builtin) . font-lock-builtin-face)
-    (,(nim-rx keyword) . font-lock-keyword-face)
-    ;; Result
-    (,(rx symbol-start "result" symbol-end) . font-lock-variable-name-face)
     ;; pragma
     (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep)))
   "Font lock expressions for Nim mode.")
+
+(defconst nim-font-lock-keywords-2
+  `((,(nim-rx (or exception type)) . font-lock-type-face)
+    (,(nim-rx constant) . font-lock-constant-face)
+    (,(nim-rx builtin) . font-lock-builtin-face)
+    (,(nim-rx keyword) . font-lock-keyword-face)
+    (,(rx symbol-start "result" symbol-end) . font-lock-variable-name-face)))
 
 (defsubst nim-syntax-count-quotes (quote-char &optional point limit)
   "Count number of quotes around point (max is 3).

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -63,7 +63,7 @@
     ;; Result
     (,(rx symbol-start "result" symbol-end) . font-lock-variable-name-face)
     ;; pragma
-    (,(nim-rx pragma) . (0 'nim-font-lock-pragma-face keep)))
+    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep)))
   "Font lock expressions for Nim mode.")
 
 (defsubst nim-syntax-count-quotes (quote-char &optional point limit)
@@ -250,6 +250,13 @@ character address of the specified TYPE."
   (when (nth 3 (save-excursion (syntax-ppss)))
     (re-search-forward "\\s|" nil t)))
 
+
+(defun nim-pragma-matcher (&optional _start-pos)
+  "Highlight pragma."
+  (nim-matcher-func
+   'nim-skip-comment-and-string
+   (lambda () (not (re-search-forward (nim-rx pragma) nil t)))
+   (lambda (ppss) (nth 8 ppss))))
 
 (defun nim-type-matcher (&optional _start-pos)
   (nim-matcher-func

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -33,16 +33,9 @@
         keep t)
      (7 font-lock-type-face keep t))
     ;; Highlight type words
-    (,(nim-rx (or identifier quoted-chars) (? "*")
-              (* " ") ":" (* " ")
-              (? (and "var " (0+ " ")))
-              (? (group (and (or "ref" "ptr") " " (* " "))))
-              (group identifier))
+    (nim-type-matcher
      (1 font-lock-keyword-face keep t)
-     (2 (if (< 0 (nth 0 (syntax-ppss)))
-            font-lock-type-face
-          'default)
-        keep))
+     (2 font-lock-type-face keep))
     ;; This only works if it’s one line
     (,(nim-rx (or "var" "let" "const" "type") (1+ " ")
               (group (or identifier quoted-chars) (? " ") (? (group "*"))))
@@ -272,6 +265,14 @@ character address of the specified TYPE."
   (when (nth 3 (save-excursion (syntax-ppss)))
     (re-search-forward "\\s|" nil t)))
 
+
+(defun nim-type-matcher (&optional _start-pos)
+  (nim-matcher-func
+   'nim-skip-comment-and-string
+   (lambda () (not (re-search-forward (nim-rx colon-type) nil t)))
+   (lambda (ppss)
+     (or (eq (nth 0 ppss) 0)
+         (not (eq ?\( (char-after (nth 1 ppss))))))))
 (defun nim-proc-matcher (&optional _start-pos)
   (nim-matcher-func
    'nim-skip-comment-and-string

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -53,23 +53,8 @@
               line-end)
      . (1 'nim-font-lock-export-face))
     ;; Number literal
-    (,(nim-rx ; u?int
-       (group int-lit)
-       (? (group (? "'") (or (and (in "uUiI") (or "8" "16" "32" "64"))
-                             (in "uU")))))
-     (1 'nim-font-lock-number-face)
-     (2 font-lock-type-face nil t))
-    (,(nim-rx ; float
-       (group (or float-lit dec-lit oct-lit bin-lit))
-              (? (group (? "'") float-suffix)))
-     (1 'nim-font-lock-number-face)
-     (2 font-lock-type-face t t)  ; exponential
-     (3 font-lock-type-face t t)) ; type
-    (,(nim-rx ; float hex
-       (group hex-lit)
-       (? (group "'" float-suffix))) ; "'" isn’t optional
-     (1 'nim-font-lock-number-face)
-     (3 font-lock-type-face nil t))
+    (nim-number-matcher
+     (0 'nim-font-lock-number-face))
     ;; other keywords
     (,(nim-rx (or exception type)) . font-lock-type-face)
     (,(nim-rx constant) . font-lock-constant-face)
@@ -273,6 +258,13 @@ character address of the specified TYPE."
    (lambda (ppss)
      (or (eq (nth 0 ppss) 0)
          (not (eq ?\( (char-after (nth 1 ppss))))))))
+
+(defun nim-number-matcher (&optional _start-pos)
+  (nim-matcher-func
+   'nim-skip-comment-and-string
+   (lambda () (not (re-search-forward (nim-rx nim-numbers) nil t)))
+   (lambda (ppss) (or (nth 3 ppss) (nth 4 ppss)))))
+
 (defun nim-proc-matcher (&optional _start-pos)
   (nim-matcher-func
    'nim-skip-comment-and-string

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -56,7 +56,10 @@
     ;; Highlight $# and $[0-9]+ inside string
     (nim-format-$-matcher . (1 font-lock-preprocessor-face prepend))
     ;; pragma
-    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep))))
+    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep)))
+  "Extra font-lock keywords.
+If you feel uncomfortable because of this font-lock keywords,
+set nil to this value by ‘nim-mode-init-hook’.")
 
 (defconst nim-font-lock-keywords-2
   `((,(nim-rx (or exception type)) . font-lock-type-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -42,16 +42,8 @@
      . (1 (if (match-string 2)
               'nim-font-lock-export-face
             font-lock-variable-name-face)))
-    ;; For multiple line properties
-    (,(nim-rx line-start (1+ " ")
-              (group
-               (or identifier quoted-chars) "*"
-               (? (and "[" word "]"))
-               (0+ (and "," (? (0+ " "))
-                        (or identifier quoted-chars) "*")))
-              (0+ " ") (or ":" "{." "=") (0+ nonl)
-              line-end)
-     . (1 'nim-font-lock-export-face))
+    ;; export properties
+    (,(nim-rx font-lock-export) . (1 'nim-font-lock-export-face))
     ;; Number literal
     (nim-number-matcher
      (0 'nim-font-lock-number-face))

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -55,8 +55,9 @@
      (1 font-lock-constant-face prepend))
     ;; Highlight $# and $[0-9]+ inside string
     (nim-format-$-matcher . (1 font-lock-preprocessor-face prepend))
-    ;; highlight word after ‘is’
-    (,(nim-rx " " symbol-start "is" symbol-end (1+ " ") (group identifier))
+    ;; Highlight word after ‘is’ and ‘distinct’
+    (,(nim-rx " " symbol-start (or "is" "distinct") symbol-end (1+ " ")
+              (group identifier))
      (1 font-lock-type-face)))
   "Extra font-lock keywords.
 If you feel uncomfortable because of this font-lock keywords,

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -41,8 +41,11 @@
               (group (or identifier quoted-chars) (? " ") (? (group "*"))))
      . (1 (if (match-string 2)
               'nim-font-lock-export-face
-            font-lock-variable-name-face)))
-    ;; export properties
+            font-lock-variable-name-face))))
+  "Font lock expressions for Nim mode.")
+
+(defvar nim-font-lock-keywords-extra
+  `(;; export properties
     (,(nim-rx font-lock-export) . (1 'nim-font-lock-export-face))
     ;; Number literal
     (nim-number-matcher
@@ -53,8 +56,7 @@
     ;; Highlight $# and $[0-9]+ inside string
     (nim-format-$-matcher . (1 font-lock-preprocessor-face prepend))
     ;; pragma
-    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep)))
-  "Font lock expressions for Nim mode.")
+    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep))))
 
 (defconst nim-font-lock-keywords-2
   `((,(nim-rx (or exception type)) . font-lock-type-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -56,7 +56,10 @@
     ;; Highlight $# and $[0-9]+ inside string
     (nim-format-$-matcher . (1 font-lock-preprocessor-face prepend))
     ;; pragma
-    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep)))
+    (nim-pragma-matcher . (0 'nim-font-lock-pragma-face keep))
+    ;; highlight word after ‘is’
+    (,(nim-rx " " symbol-start "is" symbol-end (1+ " ") (group identifier))
+     (1 font-lock-type-face)))
   "Extra font-lock keywords.
 If you feel uncomfortable because of this font-lock keywords,
 set nil to this value by ‘nim-mode-init-hook’.")

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -151,7 +151,7 @@ other tokens like ’:’ or ’=’."
     (modify-syntax-entry ?\n ">" table)
     ;; Use "." Punctuation syntax class because I got error when I
     ;; used "$" from smie.el
-    (modify-syntax-entry ?` "." table)
+    (modify-syntax-entry ?` "'" table)
 
     ;; Use _ syntax to single quote
     ;; See also `nim-syntax-propertize-function'.

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -124,6 +124,11 @@ other tokens like ’:’ or ’=’."
   :type 'hook
   :group 'nim)
 
+(defcustom nim-mode-init-hook nil
+  "This hook is called when ‘nim-mode’ is initialized."
+  :type 'hook
+  :group 'nim)
+
 (defvar nim-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "M-.") 'nim-goto-sym)

--- a/tests/syntax/backtick.nim
+++ b/tests/syntax/backtick.nim
@@ -1,0 +1,15 @@
+# test backtick highlight
+# Note that for performance reason, this highlight's regex is picky.
+
+# `single backticks` and ``double backticks``
+
+## `single backticks` and ``double backticks``
+
+#[ `single backticks` and ``double backticks`` ]#
+
+##[ `single backticks` and ``double backticks`` ]##
+
+#[ start with line start
+`single backticks`
+``double backticks``
+]#

--- a/tests/syntax/format.nim
+++ b/tests/syntax/format.nim
@@ -1,0 +1,6 @@
+# highlight $# or $[1-9][0-9] inside string for `format`
+import strutils
+
+echo """
+$1 + $2 = $#
+""".format("1", "2", "3")

--- a/tests/syntax/test_is_and_distinct.nim
+++ b/tests/syntax/test_is_and_distinct.nim
@@ -1,0 +1,11 @@
+# test highlighting a word as type face after `is` and `distinct`
+
+type
+  custom_type = tuple[a: string]
+  custom_type2 = distinct custom_type # <- highlight
+
+var it: custom_type = (a: "foo")
+if it is custom_type:
+  echo "custom_type should be highlighted as type face"
+elif it is custom_type2:
+  echo "custom_type2 should be highlighted as type face"

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -178,8 +178,8 @@
  (test-faces-by-range
   "should highlight pragmas"
   (test-concat-dir "tests/syntax/pragma.nim")
-  '(((31 . 41)  . nim-font-lock-pragma-face)
-    ((79 . 86)  . nim-font-lock-pragma-face)))
+  '(((31 . 40)  . nim-font-lock-pragma-face)
+    ((79 . 85)  . nim-font-lock-pragma-face)))
 
  ;; docstring
  (test-faces-by-range

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -235,6 +235,14 @@
     ((321 . 338) . font-lock-constant-face)
     ((340 . 359) . font-lock-constant-face)))
 
+ ;; $# and $[1-9]
+ (test-faces-by-range
+  "should highlight $# and $[1-9] inside string correctly"
+  (test-concat-dir "tests/syntax/format.nim")
+  '(((84 . 85) . font-lock-preprocessor-face)
+    ((89 . 90) . font-lock-preprocessor-face)
+    ((94 . 95) . font-lock-preprocessor-face)))
+
  ) ; end of describe function
 
 ;; Local Variables:

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -243,6 +243,14 @@
     ((89 . 90) . font-lock-preprocessor-face)
     ((94 . 95) . font-lock-preprocessor-face)))
 
+ ;; after ‘is’ operator and ‘distinct’
+ (test-faces-by-range
+  "should highlight after is operator correctly"
+  (test-concat-dir "tests/syntax/test_is_and_distinct.nim")
+  '(((132 . 142) . font-lock-type-face)
+    ((202 . 212) . font-lock-type-face)
+    ((282 . 293) . font-lock-type-face)))
+
  ) ; end of describe function
 
 ;; Local Variables:

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -220,6 +220,21 @@
   '(((55 . 61) . font-lock-type-face)))
 
 
+ ;; backticks in comment
+ (test-faces-by-range
+  "should highlight words inside backticks correctly"
+  (test-concat-dir "tests/syntax/backtick.nim")
+  '(((99 . 116) . font-lock-constant-face)
+    ((122 . 141) . font-lock-constant-face)
+    ((147 . 164) . font-lock-constant-face)
+    ((170 . 189) . font-lock-constant-face)
+    ((195 . 212) . font-lock-constant-face)
+    ((218 . 237) . font-lock-constant-face)
+    ((247 . 264) . font-lock-constant-face)
+    ((270 . 289) . font-lock-constant-face)
+    ((321 . 338) . font-lock-constant-face)
+    ((340 . 359) . font-lock-constant-face)))
+
  ) ; end of describe function
 
 ;; Local Variables:


### PR DESCRIPTION
Added some new highlights and refinements:

1. highlight word after `is`
2. highlight word after `distinct`
3. use different logic for pragma highlight.
4. highlight $# and $[1-9] for format in string
5. highlight backticks in comment

(Please merge #81 first)