### PR TITLE
Fix smie's indent

### DIFF
--- a/nim-smie.el
+++ b/nim-smie.el
@@ -226,6 +226,7 @@ See also ‘smie-rules-function’ about KIND and TOKEN."
                 (if (member "}" (assoc-default :closers nim-smie--line-info))
                     (current-indentation)
                   nim-smie-function-indent))))
+          (nim-traverse)
           (cons 'column (current-indentation))))))
 
 (defun nim-smie--close-all (token)

--- a/nim-smie.el
+++ b/nim-smie.el
@@ -116,65 +116,65 @@
 See also ‘smie-rules-function’ about KIND and TOKEN."
   (if-let ((ind (nim-smie--condition-after-equal-p)))
       (cons 'column ind)
-  (pcase (cons kind token)
-    ;; Proc
-    (`(:list-intro . "proc") (nim-smie--list-intro-proc))
-    ;; Parenthesis
-    (`(,(or :before :after) . ,(or "(" "{" "["))
-     (nim-smie--paren kind token))
-    (`(:close-all . ,(or "]" "}" ")"))
-     (nim-smie--close-all token))
-    ;; Comma
-    (`(:before . ",") (nim-smie--comma))
-    ;; "="
-    (`(,(or :before :after :list-intro) . "=")
-     (nim-smie--equal kind))
-    ;; Conditions
-    (`(:list-intro . ,(or "if" "when" "while" "elif" "block" "else" "of"))
-     (nim-smie--list-intro-conditions))
-    ;; object of/ case’s of
-    (`(,_ . "object")
-     (nim-smie--object kind))
-    (`(,_ . "of")
-     (nim-smie--of kind))
-    ;; else
-    (`(:before . "else") (nim-smie-rule-adjust-else-stmt))
-    ;; var/let/const/type/import
-    (`(:after . ,(or "var" "let" "const" "type" "import"))
-     nim-indent-offset)
-    (`(:list-intro . ,(or "var" "let" "const" "type" "import"))
-     (nim-smie--list-intro-vlcti token))
-    ;; enum
-    (`(:before . "enum")
-     (save-excursion (back-to-indentation)
-                     (cons 'column (+ (current-column) nim-indent-offset))))
-    ;; tuple
-    (`(:before . "tuple")
-     ;; ignore tuple inside proc’s args
-     (if (member (nth 2 (smie-indent--parent)) nim-smie--defuns)
-         0
+    (pcase (cons kind token)
+      ;; Proc
+      (`(:list-intro . "proc") (nim-smie--list-intro-proc))
+      ;; Parenthesis
+      (`(,(or :before :after) . ,(or "(" "{" "["))
+       (nim-smie--paren kind token))
+      (`(:close-all . ,(or "]" "}" ")"))
+       (nim-smie--close-all token))
+      ;; Comma
+      (`(:before . ",") (nim-smie--comma))
+      ;; "="
+      (`(,(or :before :after :list-intro) . "=")
+       (nim-smie--equal kind))
+      ;; Conditions
+      (`(:list-intro . ,(or "if" "when" "while" "elif" "block" "else" "of"))
+       (nim-smie--list-intro-conditions))
+      ;; object of/ case’s of
+      (`(,_ . "object")
+       (nim-smie--object kind))
+      (`(,_ . "of")
+       (nim-smie--of kind))
+      ;; else
+      (`(:before . "else") (nim-smie-rule-adjust-else-stmt))
+      ;; var/let/const/type/import
+      (`(:after . ,(or "var" "let" "const" "type" "import"))
+       nim-indent-offset)
+      (`(:list-intro . ,(or "var" "let" "const" "type" "import"))
+       (nim-smie--list-intro-vlcti token))
+      ;; enum
+      (`(:before . "enum")
        (save-excursion (back-to-indentation)
-                       (cons 'column (+ (current-column) nim-indent-offset)))))
-    ;; Colon
-    (`(,(or :before :after :list-intro) . ":")
-     (nim-smie--colon kind token))
-    ;; &
-    (`(,(or :after :list-intro) . "&")
-     (nim-smie--& kind))
-    ;; ‘empty-line-token’
-    (`(:elem . empty-line-token)
-     ;; This has to return token; not indent number.
-     ;; see ‘smie-indent-keyword’.
-     nil)
-    (`(:elem . basic)
-     (current-indentation))
-    ;; break
-    (`(,(or :before :after) . ,(or "break" "__after_break"))
-     (nim-smie--break kind))
-    ;; other keywords
-    (`(:before . ,_))
-    ;; Don’t make ambiguous indentation
-    (_ 0))))
+                       (cons 'column (+ (current-column) nim-indent-offset))))
+      ;; tuple
+      (`(:before . "tuple")
+       ;; ignore tuple inside proc’s args
+       (if (member (nth 2 (smie-indent--parent)) nim-smie--defuns)
+           0
+         (save-excursion (back-to-indentation)
+                         (cons 'column (+ (current-column) nim-indent-offset)))))
+      ;; Colon
+      (`(,(or :before :after :list-intro) . ":")
+       (nim-smie--colon kind token))
+      ;; &
+      (`(,(or :after :list-intro) . "&")
+       (nim-smie--& kind))
+      ;; ‘empty-line-token’
+      (`(:elem . empty-line-token)
+       ;; This has to return token; not indent number.
+       ;; see ‘smie-indent-keyword’.
+       nil)
+      (`(:elem . basic)
+       (current-indentation))
+      ;; break
+      (`(,(or :before :after) . ,(or "break" "__after_break"))
+       (nim-smie--break kind))
+      ;; other keywords
+      (`(:before . ,_))
+      ;; Don’t make ambiguous indentation
+      (_ 0))))
 
 (defun nim-set-force-indent (indent &optional override)
   (when (or override (not (cdr (assoc :force-indent nim-smie--line-info))))

--- a/nim-smie.el
+++ b/nim-smie.el
@@ -83,14 +83,14 @@
         ("case" exp "elif" exp "else" ":" stmt)
         ("try" exp "except" exp "except" exp "finally" ":" stmt)
         ("while" any ":" stmt)
-        ("for" exp "in" any ":" stmt)
+        ("for" any ":" stmt)
         ("block" any ":" stmt)))
      ;; You can choose: `assoc', `left', `right' or `nonassoc'.
      '((nonassoc "if" "when" "case" "for" "try")
        (assoc "of") (assoc "elif") (assoc "else"))
      '((assoc "case") (assoc "else") (assoc ":"))
      '((nonassoc "case" "object") (assoc "of"))
-     '((assoc "for") (assoc "in") (assoc ":"))
+     '((assoc "for") (assoc ":"))
      '((assoc "try") (assoc "except") (assoc "finally") (assoc  ":"))
      '((assoc "=") (assoc "object"))
      ;; Functions

--- a/tests/indents/SMIE/case-stmt.nim
+++ b/tests/indents/SMIE/case-stmt.nim
@@ -62,3 +62,22 @@ of true:
             echo "b"
 else:
   echo "no"
+
+
+# check `var` and `else`
+var x = "foo"
+var a = case x:
+          of "f": echo "f"
+          of "fo": echo "fo"
+          of "foo": echo "foo"
+          else: "else"
+echo "check this line's indent"
+
+# check `let` and `else`
+let x = "bar"
+let a = case x
+        of "f": echo "f"
+        of "fo": echo "fo"
+        of "foo": echo "foo"
+        else: "else"
+echo "check this line's indent"

--- a/tests/indents/SMIE/if-stmt.nim
+++ b/tests/indents/SMIE/if-stmt.nim
@@ -41,3 +41,14 @@ if s.kind in {skResult, skTemp}:
 
 if true == 1 in (1..10):
   echo "bar"
+
+
+# check `var` and `else`
+var a = if true: "a"
+        else: "b"
+echo "check this line's indent"
+
+# check `let` and `else`
+let b = if true: "a"
+        else: "b"
+echo "check this line's indent"

--- a/tests/indents/SMIE/if-stmt.nim
+++ b/tests/indents/SMIE/if-stmt.nim
@@ -33,3 +33,11 @@ var y = if true:
           echo "bar"
         else:
           echo "buzz"
+
+
+# check indent including `in`
+if s.kind in {skResult, skTemp}:
+  echo "foo"
+
+if true == 1 in (1..10):
+  echo "bar"

--- a/tests/indents/SMIE/type.nim
+++ b/tests/indents/SMIE/type.nim
@@ -25,3 +25,14 @@ type
   B* = ref RootObj # check this line's indent
   C* =
     object # check if there is other "object"
+
+
+# check indent after pragma
+type
+  typeA* = proc(): cint {.cdecl.}
+  typeB* = proc(): cint {.cdecl.}
+  typeC* {.importc: "struct emacs_runtime",
+           header: "<emacs-module.h>".} = object
+    size: ptrdiff_t
+    soemthing: proc(): ptr foo {.cdecl.}
+    # check this line's indent

--- a/tests/indents/SMIE/when-stmt.nim
+++ b/tests/indents/SMIE/when-stmt.nim
@@ -25,3 +25,14 @@ var y = when true:
           echo "bar"
         else:
           echo "buzz"
+
+
+# check `var` and `else`
+var a = when true: "a"
+        else: "b"
+echo "check this line's indent"
+
+# check `let` and `else`
+let b = when true: "a"
+        else: "b"
+echo "check this line's indent"


### PR DESCRIPTION
Fix wrong indent if the sentence is including `in`.
(note that we already have `for x in ..` test)
EDIT:
I noticed this wrong indent when I visited Nim/compiler/nimfix/pretty.nim
and copied from it to make the test.