### PR TITLE
Auto completion for system.nim

### DIFF
--- a/company-nim.el
+++ b/company-nim.el
@@ -68,15 +68,15 @@
 
 (defun company-nim--format-candidate (cand)
   "Formats candidate for company, attaches properties to text."
-  (propertize (car (last (nim-epc-qualifiedPath cand)))
-              :nim-location-line (nim-epc-line cand)
-              :nim-location-column (nim-epc-column cand)
-              :nim-type (nim-epc-forth cand)
-              :nim-doc (nim-epc-doc cand)
-              :nim-file (nim-epc-filePath cand)
-              :nim-sk (nim-epc-symkind cand)
-              :nim-sig (assoc-default (nim-epc-symkind cand) company-nim-type-abbrevs))
-  )
+  (propertize
+   (car (last (nim-epc-qualifiedPath cand)))
+   :nim-location-line (nim-epc-line cand)
+   :nim-location-column (nim-epc-column cand)
+   :nim-type (nim-epc-forth cand)
+   :nim-doc (nim-epc-doc cand)
+   :nim-file (nim-epc-filePath cand)
+   :nim-sk (nim-epc-symkind cand)
+   :nim-sig (assoc-default (nim-epc-symkind cand) company-nim-type-abbrevs)))
 
 (defun company-nim--format-candidates (arg candidates)
   "Filters candidates, and returns formatted candadates lists."
@@ -84,13 +84,17 @@
           (if (string-equal arg ".")
               candidates
             (cl-remove-if-not
-             (lambda (c) (company-nim-fuzzy-match arg (car (last (nim-epc-qualifiedPath c)))))
+             (lambda (c)
+               (company-nim-fuzzy-match
+                arg (car (last (nim-epc-qualifiedPath c)))))
              candidates))))
 
 
 (defun company-nim-candidates (arg callback)
   (when (derived-mode-p 'nim-mode)
-    (nim-call-epc 'sug (lambda (x) (funcall callback (company-nim--format-candidates arg x))))))
+    (nim-call-epc
+     'sug
+     (lambda (x) (funcall callback (company-nim--format-candidates arg x))))))
 
 
 (defun company-nim-prefix (&optional use-dotty-syntax)

--- a/company-nim.el
+++ b/company-nim.el
@@ -86,9 +86,12 @@
             (cl-remove-if-not
              (lambda (c)
                (company-nim-fuzzy-match
-                arg (car (last (nim-epc-qualifiedPath c)))))
+                arg
+                (let ((name (car (last (nim-epc-qualifiedPath c)))))
+                  (format "%s%s"
+                          (substring name 0 1)
+                          (downcase (substring name 1 (length name)))))))
              candidates))))
-
 
 (defun company-nim-candidates (arg callback)
   (when (derived-mode-p 'nim-mode)

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -67,7 +67,7 @@ hierarchy, starting from CURRENT-DIR"
                    nil)))
         (let ((epc-process (epc:start-epc
                             nim-nimsuggest-path
-                            (append nim-suggest-options
+                            (append nim-suggest-options nim-suggest-local-options
                                     ;; Add nimscript specific symbols in nimscript-mode
                                     (when (eq 'nimscript-mode major-mode)
                                       '("--define:nimscript" "--define:nimconfig"))

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -68,6 +68,10 @@ hierarchy, starting from CURRENT-DIR"
         (let ((epc-process (epc:start-epc
                             nim-nimsuggest-path
                             (append nim-suggest-options
+                                    ;; Add nimscript specific symbols in nimscript-mode
+                                    (when (eq 'nimscript-mode major-mode)
+                                      '("--define:nimscript" "--define:nimconfig"))
+                                    ;; Essential options
                                     (list "--epc" "--verbosity:0" main-file)))))
           (push (cons main-file epc-process) nim-epc-processes-alist)
           epc-process))))

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -143,6 +143,11 @@ epc function."
                  (const :tag "" nil))
   :group 'nim)
 
+(defvar nim-suggest-local-options '()
+  "Options for Nimsuggest.
+Please use this variable to set nimsuggest’s options for
+specific directory or buffer.  See also ‘dir-locals-file’.")
+
 (defvar nim-suggest-ignore-dir-regex
   (rx (or "\\" "/") (in "nN") "im" (or "\\" "/") "compiler" (or "\\" "/")))
 (defvar nim-inside-compiler-dir-p nil)


### PR DESCRIPTION
- added `--define:nimscript` and `--define:nimconfig` options for nimscript files
  (it allows you to more precise completion)
- added a function to get data from system.nim for auto-completion
  and it includes nimscript's data as well because of the change I wrote above.

(sorry for frequency change. I didn't know I could specify --define:nimscirpt)