### PR TITLE
Deal with spaces after open parens

### DIFF
--- a/nim-smie.el
+++ b/nim-smie.el
@@ -458,7 +458,10 @@ See also ‘smie-rules-function’ about KIND and TOKEN."
             (setq offset
                   (if (looking-at "{.")
                       (+ 2 (current-column))
-                    (1+ (current-column)))))
+                    (while (progn
+                              (forward-char)
+                              (looking-at (rx blank)))
+                    (current-column)))))
           (cons 'column offset))))))
 
 (defun nim-smie--of (kind)

--- a/tests/indents/SMIE/paren-space.nim
+++ b/tests/indents/SMIE/paren-space.nim
@@ -1,0 +1,15 @@
+proc parenNoSpace(n: int,
+                  f: float,
+                  str: string) =
+  echo "0"
+
+
+proc parenOneSpace( n: int,
+                    f: float,
+                    str: string ) =
+  echo "1"
+
+proc parenTwoSpaces(  n: int,
+                      f: float,
+                      str: string  ) =
+  echo "2"


### PR DESCRIPTION
I (and some others) like to put a space inside my parentheses when they surround arguments, like `f( x, y )` rather than `f(x,y)`. This patch makes nim-mode indent comma-separated expressions on multiple lines correctly when the parentheses surrounding them have extra space. The added test demonstrates the effect.