### PR TITLE
Pretty symbols

### DIFF
--- a/nim-vars.el
+++ b/nim-vars.el
@@ -135,6 +135,14 @@ other tokens like ’:’ or ’=’."
   :type 'hook
   :group 'nim)
 
+(defcustom nim-pretty-triple-double-quotes
+  ;; What character should be default? („…“, “…”, ‘…’, or etc.?)
+  (cons ?“ ?”)
+  "Change triple double quotes to another quote form.
+This configuration is enabled only in ‘prettify-symbols-mode’."
+  :type 'cons
+  :group 'nim)
+
 (defcustom nim-suggest-options '("--v2")
   "Options for Nimsuggest.
 Note that ‘--verbosity:0’ and ‘--epc’ are automatically passed nim-mode’s


### PR DESCRIPTION
added a feature to convert triple double quotes to another form for pretty-symbols-mode.
(the first line's “foo”)
![screenshot from 2016-03-19 14 41 21](https://cloud.githubusercontent.com/assets/1082473/13901434/e4e835b0-ede0-11e5-9b85-5f141d21bd4c.png)
