### PR TITLE
Fix moving around cursor in flycheck async nim

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,5 +1,8 @@
-(source gnu)
 (source melpa-stable)
+;; Place GNU repository here to prior melpa-stable
+;; repositry because company-mode includes test directory
+;; and buttercup somehow executes the tests.
+(source gnu)
 
 (files "*.el")
 

--- a/flycheck-nim-async.el
+++ b/flycheck-nim-async.el
@@ -66,7 +66,8 @@
 (defun flycheck-epc-define-checker (checker parser patterns base-func mode)
   "Define flycheck CHECKER for EPC based on PARSER and PATTERNS.
 
-The BASE-FUNC is a function that returns string."
+The BASE-FUNC is a function that returns string.
+MODE is list of ‘major-mode’, which you want to enable."
   (let ((command   '("echo dummy command")))
     (pcase-dolist
         (`(,prop . ,value)

--- a/flycheck-nim-async.el
+++ b/flycheck-nim-async.el
@@ -138,13 +138,11 @@ The BASE-FUNC is a function that returns string."
   "Check current buffer using nimsuggest ’chk option."
   (interactive)
   (when (and nim-nimsuggest-path (derived-mode-p 'nim-mode))
-    (save-excursion
-      (goto-char (point-max))
-      (nim-call-epc
-       'chk
-       (if force
-           'flycheck-nim-async-force-update
-         'flycheck-nim-async-callback)))))
+    (nim-call-epc
+     'chk
+     (if force
+         'flycheck-nim-async-force-update
+       'flycheck-nim-async-callback))))
 
 (defvar nimsuggest-check-output "")
 (defun flycheck-nim-async-callback (output &optional force)

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -114,10 +114,16 @@ The callback is called with a list of nim-epc structs."
         (epc:call-deferred
          (nim-find-or-create-epc)
          method
-         (list (buffer-file-name)
-               (line-number-at-pos)
-               (current-column)
-               tempfile))
+         (cl-case method
+           (chk
+            (list (buffer-file-name)
+                  -1 -1
+                  tempfile))
+           (t
+            (list (buffer-file-name)
+                  (line-number-at-pos)
+                  (current-column)
+                  tempfile))))
         (deferred:nextc it
           (lambda (x) (funcall callback (nim-parse-epc x method))))
         (deferred:watch it

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -1,11 +1,9 @@
-;;; nim-suggest.el --- -*- lexical-binding: t -*-
+;;; nim-suggest.el --- a plugin to use nimsuggest from Emacs -*- lexical-binding: t -*-
 ;;; Commentary:
 
 ;;
 
 ;;; Code:
-
-;;; Completion
 
 (require 'nim-vars)
 (require 'epc)
@@ -107,7 +105,7 @@ def: where the symbol is defined
 use: where the symbol is used
 dus: def + use
 
-The callback is called with a list of nim-epc structs."
+The CALLBACK is called with a list of ‘nim-epc’ structs."
   (unless nim-inside-compiler-dir-p
     (let ((tempfile (nim-save-buffer-temporarly)))
       (deferred:$


### PR DESCRIPTION
when I moved a nim file to another nim file, somehow my cursor went to bottom of buffer.
(`save-excursion` function should prevent, but it doesn't...)
This PR fixes above problem.