### PR TITLE
Fix package dependencies #100

### DIFF
--- a/nim-mode.el
+++ b/nim-mode.el
@@ -7,7 +7,7 @@
 ;; Version: 0.2.0
 ;; Keywords: nim languages
 ;; Compatibility: GNU Emacs 24.4
-;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1"))
+;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1") (flycheck "0.25.1") (company "0.8.12"))
 ;;
 ;; Taken over from James H. Fisher <jameshfisher@gmail.com>
 ;;


### PR DESCRIPTION
for flycheck-nim-async and company-mode

(just remainder for me, MELPA refers pkg dependencies of nim-mode.el, not each files
because `nim-mode` is repository name)