### PR TITLE
Refactor for debugging

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -17,3 +17,33 @@ The tests are written with
 look at the existing tests. Currently, code samples for testing are in
 the `tests/samples/` subdirectory. The naming convention is
 `something-actual.nim` and `something-expected.nim`.
+
+Making New Issues
+=================
+
+nim-mode's most features are depending on nimsuggest, so if you think
+your issue is related to nimsuggest, please minimize the
+problem to avoid ambiguity.
+
+As example of turning off nimsuggest features, you can configure like:
+
+```lisp
+;; place this configuration in your .emacs or somewhere before emacs
+;; load nim-mode and you may need to reboot your Emacs to check.
+(defconst nim-nimsuggest-path nil)
+```
+
+Generally, nim-mode uses nimsuggest by `company-mode`, `eldoc-mode`,
+`flycheck-mode`, `nim-thing-at-point`, and `nim-goto-sym` (goto definition).
+
+If you are completely new to Emacs, please check next section as well.
+
+Emacs Configuration or Debugging
+================================
+
+Some configuration variables are placed in nim-vars.el. Please take a
+look if you are interested in. (indenting, faces, nimsuggest, etc.)
+
+If you new to Emacs, please visit [here](https://github.com/chrisdone/elisp-guide)
+and check `Evaluation` section (or other stuff). The C-x C-e or C-M-x
+is really convenient way to debug if you get errors in your configuration file.

--- a/contributing.md
+++ b/contributing.md
@@ -21,7 +21,7 @@ the `tests/samples/` subdirectory. The naming convention is
 Making New Issues
 =================
 
-nim-mode's most features are depending on nimsuggest, so if you think
+Most of `nim-mode`s features are depending on nimsuggest, so if you think
 your issue is related to nimsuggest, please minimize the
 problem to avoid ambiguity.
 
@@ -33,7 +33,7 @@ As example of turning off nimsuggest features, you can configure like:
 (defconst nim-nimsuggest-path nil)
 ```
 
-Generally, nim-mode uses nimsuggest by `company-mode`, `eldoc-mode`,
+Generally, `nim-mode` uses nimsuggest via `company-mode`, `eldoc-mode`,
 `flycheck-mode`, `nim-thing-at-point`, and `nim-goto-sym` (goto definition).
 
 If you are completely new to Emacs, please check next section as well.

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -189,6 +189,7 @@ DEFS is group of definitions from nimsuggest."
 (defun nim-eldoc-setup ()
   "Setup eldoc configuration for nim-mode."
   (when (and (derived-mode-p 'nim-mode) nim-nimsuggest-path)
+    (message "nim-mode: eldoc feature turned on automatically")
     (setq-local eldoc-documentation-function 'nim-eldoc-function)))
 
 ;;;###autoload

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -42,7 +42,7 @@
 (defun nim-eldoc-function ()
   "Return a doc string appropriate for the current context, or nil."
   (interactive)
-  (when (and nim-nimsuggest-path (or eldoc-mode global-eldoc-mode)
+  (when (and (or eldoc-mode global-eldoc-mode)
              (not (eq ?\  (char-after (point)))))
     (unless (nim-eldoc-same-try-p)
       (save-excursion
@@ -188,7 +188,8 @@ DEFS is group of definitions from nimsuggest."
 ;;;###autoload
 (defun nim-eldoc-setup ()
   "Setup eldoc configuration for nim-mode."
-  (when (and (derived-mode-p 'nim-mode) nim-nimsuggest-path)
+  (when (and (derived-mode-p 'nim-mode) (nim-suggest-available-p)
+             (or eldoc-mode global-eldoc-mode))
     (message "nim-mode: eldoc feature turned on automatically")
     (setq-local eldoc-documentation-function 'nim-eldoc-function)))
 

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -73,7 +73,7 @@
   :group 'nim
 
   ;; init hook
-  (run-hooks nim-mode-init-hook)
+  (run-hooks 'nim-mode-init-hook)
 
   (setq-local nim-inside-compiler-dir-p
               (when (and buffer-file-name

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -62,6 +62,10 @@
           (push (cons main-file epc-process) nim-epc-processes-alist)
           epc-process))))
 
+(defun nim-suggest-available-p ()
+  (and nim-nimsuggest-path
+       (not nim-inside-compiler-dir-p)))
+
 (defun nim-call-epc (method callback)
   "Call the nimsuggest process on point.
 
@@ -76,7 +80,7 @@ use: where the symbol is used
 dus: def + use
 
 The CALLBACK is called with a list of ‘nim-epc’ structs."
-  (unless nim-inside-compiler-dir-p
+  (when (nim-suggest-available-p)
     (let ((tempfile (nim-save-buffer-temporarly))
           (buf (current-buffer)))
       (deferred:$


### PR DESCRIPTION
At #108, I realized current nim-mode wasn't easy to distinguish problems.
(whether it's nimsuggest related or font-lock related, for example)

This PR allows users easy setting to turn off some feature for nim-mode

1. turn off nimsuggest: `(defconst nim-nimsuggest-path nil)`
2. ~~turn off syntax-highlight~~: `(defconst nim-font-lock-keyword-list nil)`
   (this feature didn't pass test, so I removed from this PR)
