### PR TITLE
Fix flycheck warning

### DIFF
--- a/flycheck-nim-async.el
+++ b/flycheck-nim-async.el
@@ -77,7 +77,7 @@ MODE is list of ‘major-mode’, which you want to enable."
 
 (defun flycheck-epc-find-first-checker ()
   (cl-loop for checker in flycheck-checkers
-           for modes = (flycheck-checker-modes checker)
+           for modes = (flycheck-checker-get checker 'modes)
            if (memq major-mode modes)
            collect (cl-return checker)))
 

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -7,7 +7,7 @@
 ;; Version: 0.2.0
 ;; Keywords: nim languages
 ;; Compatibility: GNU Emacs 24.4
-;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1") (flycheck "0.25.1") (company "0.8.12"))
+;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1") (flycheck "28") (company "0.8.12"))
 ;;
 ;; Taken over from James H. Fisher <jameshfisher@gmail.com>
 ;;


### PR DESCRIPTION
In latest flycheck, flycheck-checker-modes function doesn't exist, so
I used flycheck-checker-get function instead.