### PR TITLE
Change font-lock-highlight by font-lock-maximum-decoration

### DIFF
--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -191,7 +191,8 @@ DEFS is group of definitions from nimsuggest."
   (when (and (derived-mode-p 'nim-mode) (nim-suggest-available-p)
              (or eldoc-mode global-eldoc-mode))
     (message "nim-mode: eldoc feature turned on automatically")
-    (setq-local eldoc-documentation-function 'nim-eldoc-function)))
+    (add-function :before-until (local 'eldoc-documentation-function)
+                  #'nim-eldoc-function)))
 
 ;;;###autoload
 (add-hook 'nim-mode-hook 'nim-eldoc-setup)

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -143,17 +143,30 @@
   (nim--common-init)
 
   ;; Font lock
-  (setq-local font-lock-defaults
-              `(,(append nim-font-lock-keywords
-                         nim-font-lock-keywords-extra
-                         nim-font-lock-keywords-2
-                         nim-font-lock-keywords-3)
-                nil nil nil nil
-                (font-lock-syntactic-face-function
-                 . nim-font-lock-syntactic-face-function))))
+  (nim--set-font-lock-keywords 'nim-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.nim\\'" . nim-mode))
+
+(defun nim--set-font-lock-keywords (mode)
+  (let ((keywords
+         (cl-case mode
+           (nim-mode
+            (append nim-font-lock-keywords
+                    nim-font-lock-keywords-extra
+                    nim-font-lock-keywords-2
+                    nim-font-lock-keywords-3))
+           (nimscript-mode
+            (append nim-font-lock-keywords
+                    nim-font-lock-keywords-extra
+                    nim-font-lock-keywords-2
+                    ;; Add extra keywords for NimScript
+                    nimscript-keywords)))))
+    (setq-local font-lock-defaults
+              `(,keywords
+                nil nil nil nil
+                (font-lock-syntactic-face-function
+                 . nim-font-lock-syntactic-face-function)))))
 
 (defun nim-indent-post-self-insert-function ()
   "Adjust indentation after insertion of some characters.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -67,29 +67,13 @@
         font-lock-comment-face)
     font-lock-string-face))
 
-;;;###autoload
-(define-derived-mode nim-mode prog-mode "Nim"
-  "A major mode for the Nim programming language."
-  :group 'nim
-
-  ;; init hook
-  (run-hooks 'nim-mode-init-hook)
-
+(defun nim--common-init ()
+  "Common configuration for ‘nim-mode’ and ‘nimscript-mode’."
   (setq-local nim-inside-compiler-dir-p
               (when (and buffer-file-name
                          (string-match
                           nim-suggest-ignore-dir-regex buffer-file-name))
                 t))
-
-  ;; Font lock
-  (setq-local font-lock-defaults
-              `(,(append nim-font-lock-keywords
-                         nim-font-lock-keywords-extra
-                         nim-font-lock-keywords-2
-                         nim-font-lock-keywords-3)
-                nil nil nil nil
-                (font-lock-syntactic-face-function
-                 . nim-font-lock-syntactic-face-function)))
 
   ;; Comment
   (setq-local comment-use-syntax t)
@@ -147,6 +131,26 @@
 ;; add ‘nim-indent-function’ to electric-indent’s
 ;; blocklist. ‘electric-indent-inhibit’ isn’t enough for old emacs.
 (add-to-list 'electric-indent-functions-without-reindent 'nim-indent-line)
+
+;;;###autoload
+(define-derived-mode nim-mode prog-mode "Nim"
+  "A major mode for the Nim programming language."
+  :group 'nim
+
+  ;; init hook
+  (run-hooks 'nim-mode-init-hook)
+
+  (nim--common-init)
+
+  ;; Font lock
+  (setq-local font-lock-defaults
+              `(,(append nim-font-lock-keywords
+                         nim-font-lock-keywords-extra
+                         nim-font-lock-keywords-2
+                         nim-font-lock-keywords-3)
+                nil nil nil nil
+                (font-lock-syntactic-face-function
+                 . nim-font-lock-syntactic-face-function))))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.nim\\'" . nim-mode))

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -421,15 +421,12 @@ character address of the specified TYPE."
 
 (defun nim-syntax-disable-maybe ()
   "Turn off some syntax highlight if buffer size is greater than limit.
-The limit refers to ‘nim-syntax-disable-limit’."
+The limit refers to ‘nim-syntax-disable-limit’.  This function
+will be used if only user didn't set ‘font-lock-maximum-decoration’."
   (when (and nim-syntax-disable-limit
-             (< nim-syntax-disable-limit (point-max)))
-    (cl-mapcar (lambda (s) (apply `((lambda () (setq-local ,s nil)))))
-               nim-syntax-disable-keywords-list)
-    (message (concat "nim-mode: this buffer size was greater than "
-                     "nim-syntax-disable-limit(%d), so some syntax highlights "
-                     "were turned off.")
-             nim-syntax-disable-limit)))
+             (< nim-syntax-disable-limit (point-max))
+             (eq t font-lock-maximum-decoration))
+    (setq-local font-lock-maximum-decoration 2)))
 
 (add-hook 'nim-mode-init-hook 'nim-syntax-disable-maybe)
 

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -58,7 +58,9 @@
     ;; Highlight word after ‘is’ and ‘distinct’
     (,(nim-rx " " symbol-start (or "is" "distinct") symbol-end (1+ " ")
               (group identifier))
-     (1 font-lock-type-face)))
+     (1 font-lock-type-face))
+    ;; pragma
+    (nim-pragma-matcher . (4 'nim-font-lock-pragma-face)))
   "Extra font-lock keywords.
 If you feel uncomfortable because of this font-lock keywords,
 set nil to this value by ‘nim-mode-init-hook’.")
@@ -94,8 +96,7 @@ set nil to this value by ‘nim-mode-init-hook’.")
                    (nim-keywords . font-lock-keyword-face))
     for (keywords . face) in pairs
     collect (cons (nim--format-keywords keywords) face))
-   `((,(rx symbol-start "result" symbol-end) . font-lock-variable-name-face)
-     (nim-pragma-matcher . (4 'nim-font-lock-pragma-face)))))
+   `((,(rx symbol-start "result" symbol-end) . font-lock-variable-name-face))))
 
 (defvar nim-font-lock-keywords-3
   (list (cons (nim--format-keywords 'nim-builtins-without-nimscript)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -101,6 +101,17 @@ set nil to this value by ‘nim-mode-init-hook’.")
   (list (cons (nim--format-keywords 'nim-builtins-without-nimscript)
               font-lock-builtin-face)))
 
+(defvar nimscript-keywords
+  (append
+   `(,(cons (nim--format-keywords 'nimscript-builtins)
+            font-lock-builtin-face)
+     ,(cons (nim--format-keywords 'nimscript-variables)
+            font-lock-variable-name-face))
+   `((,(rx symbol-start "task" symbol-end (1+ " ")
+           (group  symbol-start (or "build" "tests" "bench") symbol-end))
+      (1 font-lock-builtin-face))
+     ("\\_<ScriptMode\\_>" (0 font-lock-type-face)))))
+
 (defsubst nim-syntax-count-quotes (quote-char &optional point limit)
   "Count number of quotes around point (max is 3).
 QUOTE-CHAR is the quote char to count.  Optional argument POINT is

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -241,7 +241,7 @@ It makes underscores and dots word constituent chars.")
 
 (defconst nim-keywords
   '("addr" "and" "as" "asm" "atomic" "bind" "block" "break" "case"
-    "cast" "concept" "const" "continue" "converter" "discard" "distinct" "div"
+    "cast" "concept" "const" "continue" "converter" "defer" "discard" "distinct" "div"
     "do" "elif" "else" "end" "enum" "except" "export" "finally" "for" "from"
     "generic" "if" "import" "in" "include" "interface" "isnot"
     "iterator" "lambda" "let" "macro" "method" "mixin" "mod" "nil" "not"

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -174,12 +174,6 @@ See also ‘nim-syntax-disable-keywords-list’."
                  (const :tag "nil" nil))
   :group 'nim)
 
-(defvar nim-syntax-disable-keywords-list
-  '(nim-font-lock-keywords
-    nim-font-lock-keywords3
-    nim-font-lock-keywords-extra)
-  "Font-lock-keywords when current buffer size is greater than ‘nim-syntax-disable-limit’.")
-
 ;; Syntax table
 (defconst nim-mode-syntax-table
   (let ((table (make-syntax-table)))

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -241,9 +241,9 @@ It makes underscores and dots word constituent chars.")
 
 (defconst nim-keywords
   '("addr" "and" "as" "asm" "atomic" "bind" "block" "break" "case"
-    "cast" "concept" "const" "continue" "converter" "defer" "discard" "distinct" "div"
-    "do" "elif" "else" "end" "enum" "except" "export" "finally" "for" "from"
-    "generic" "if" "import" "in" "include" "interface" "isnot"
+    "cast" "concept" "const" "continue" "converter" "defer" "discard" "distinct"
+    "div" "do" "elif" "else" "end" "enum" "except" "export" "finally" "for"
+    "from" "generic" "if" "import" "in" "include" "interface" "isnot"
     "iterator" "lambda" "let" "macro" "method" "mixin" "mod" "nil" "not"
     "notin" "object" "of" "or" "out" "proc" "ptr" "raise" "ref" "return"
     "shared" "shl" "shr" "static" "template" "try" "tuple" "type" "using"

--- a/nimscript-mode.el
+++ b/nimscript-mode.el
@@ -36,12 +36,15 @@
      ("\\_<ScriptMode\\_>" (0 font-lock-type-face)))))
 
 ;;;###autoload
-(define-derived-mode nimscript-mode nim-mode "NimScript"
+(define-derived-mode nimscript-mode prog-mode "NimScript"
   "A major-mode for NimScript files.
 This major-mode is activated when you enter *.nims and *.nimble
 suffixed files, but if it’s .nimble file, also another logic is
 applied. See also ‘nimscript-mode-maybe’."
   :group 'nim
+
+  (nim--common-init)
+
   (setq-local font-lock-defaults
               `(,(append
                   nim-font-lock-keywords

--- a/nimscript-mode.el
+++ b/nimscript-mode.el
@@ -24,17 +24,6 @@
 (require 'nim-syntax)
 (require 'nim-mode)
 
-(defvar nimscript-keywords
-  (append
-   `(,(cons (nim--format-keywords 'nimscript-builtins)
-            font-lock-builtin-face)
-     ,(cons (nim--format-keywords 'nimscript-variables)
-            font-lock-variable-name-face))
-   `((,(rx symbol-start "task" symbol-end (1+ " ")
-           (group  symbol-start (or "build" "tests" "bench") symbol-end))
-      (1 font-lock-builtin-face))
-     ("\\_<ScriptMode\\_>" (0 font-lock-type-face)))))
-
 ;;;###autoload
 (define-derived-mode nimscript-mode prog-mode "NimScript"
   "A major-mode for NimScript files.
@@ -45,16 +34,7 @@ applied. See also ‘nimscript-mode-maybe’."
 
   (nim--common-init)
 
-  (setq-local font-lock-defaults
-              `(,(append
-                  nim-font-lock-keywords
-                  nim-font-lock-keywords-extra
-                  nim-font-lock-keywords-2
-                  ;; Add extra keywords for NimScript
-                  nimscript-keywords)
-                nil nil nil nil
-                (font-lock-syntactic-face-function
-                 . nim-font-lock-syntactic-face-function))))
+  (nim--set-font-lock-keywords 'nimscript-mode))
 
 ;;;###autoload
 (defun nimscript-mode-maybe ()


### PR DESCRIPTION
`font-lock-maximum-decoration` variable is normal way to change font lock highlight in Emacs. (and I didn't know that until recently)