### PR TITLE
Fix comment highlight and eldoc support on org mode

### DIFF
--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -195,7 +195,7 @@ DEFS is group of definitions from nimsuggest."
                   #'nim-eldoc-function)))
 
 ;;;###autoload
-(add-hook 'nim-mode-hook 'nim-eldoc-setup)
+(add-hook 'nim-common-init-hook 'nim-eldoc-setup)
 
 (provide 'nim-eldoc)
 ;;; nim-eldoc.el ends here

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -69,6 +69,8 @@
 
 (defun nim--common-init ()
   "Common configuration for ‘nim-mode’ and ‘nimscript-mode’."
+  (run-hooks 'nim-common-init-hook)
+
   (setq-local nim-inside-compiler-dir-p
               (when (and buffer-file-name
                          (string-match

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -124,6 +124,10 @@
             #'nim-indent-post-self-insert-function 'append 'local)
   (add-hook 'which-func-functions #'nim-info-current-defun nil t)
 
+  ;; Workaround with org
+  (when (and (fboundp 'org-in-src-block-p) (org-in-src-block-p))
+    (modify-syntax-entry ?# "<" nim-mode-syntax-table))
+
   ;; Because indentation is not redundant, we cannot safely reindent code.
   (setq-local electric-indent-inhibit t)
   (setq-local electric-indent-chars '(?: ?\s))

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -64,7 +64,12 @@
 
 (defun nim-suggest-available-p ()
   (and nim-nimsuggest-path
-       (not nim-inside-compiler-dir-p)))
+       (not nim-inside-compiler-dir-p)
+       ;; Prevent turn on nimsuggest related feature on org-src block
+       (not (eq major-mode 'org-mode))
+       (not (and (fboundp 'org-in-src-block-p)
+                 (or (org-in-src-block-p)
+                     (org-in-src-block-p t))))))
 
 (defun nim-call-epc (method callback)
   "Call the nimsuggest process on point.

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -113,6 +113,11 @@ other tokens like ’:’ or ’=’."
   :type 'hook
   :group 'nim)
 
+(defcustom nim-common-init-hook nil
+  "A hook for both nim-mode and nimscript-mode."
+  :type 'hook
+  :group 'nim)
+
 (defcustom nim-pretty-triple-double-quotes
   ;; What character should be default? („…“, “…”, ‘…’, or etc.?)
   (cons ?“ ?”)

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -174,7 +174,7 @@ See also ‘nim-syntax-disable-keywords-list’."
   :group 'nim)
 
 ;; Syntax table
-(defconst nim-mode-syntax-table
+(defvar nim-mode-syntax-table
   (let ((table (make-syntax-table)))
     ;; Give punctuation syntax to ASCII that normally has symbol
     ;; syntax or has word syntax and isn't a letter.


### PR DESCRIPTION
Fixed
1. unhighlight single comment on org src block
2. turn off nim-eldoc on org src block (otherwise it emits annoying output)