### PR TITLE
Add nim-capf and nimsuggest-mode

### DIFF
--- a/Cask
+++ b/Cask
@@ -9,7 +9,6 @@
 (development
  (depends-on "buttercup")
  (depends-on "epc")
- (depends-on "company")
  (depends-on "commenter")
  (depends-on "flycheck")
  (depends-on "let-alist")

--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
-nim-mode
+nim-mode [![Travis CI](https://travis-ci.org/nim-lang/nim-mode.svg?branch=master)](https://travis-ci.org/nim-lang/nim-mode)
 ===========
 
-[![Travis CI](https://travis-ci.org/nim-lang/nim-mode.svg?branch=master)](https://travis-ci.org/nim-lang/nim-mode)
+A major mode for editing Nim source code
 
-* Install nim either by the [official download](http://nim-lang.org/download.html) or your systems package manager if available.
+## Note (9/5/2016)
+company-mode's configuration (adding company-backends) is no longer
+required for auto-completion. capf (completion-at-point-function),
+which is Emacs's default feature was added and company-mode also
+support this feature for auto-completion.
+
+So, you can remove below configuration if you have:
+
+```lisp
+(add-to-list 'company-backends
+               '(company-nim :with company-nim-builtin))
+```
+
+Also `nimsuggest-mode` was newly added. So if you were already using
+nim-mode, please take a look nimsuggest's installing section to
+activate `nimsuggest-mode`.
+
+## Installation
+
 * Install `nim-mode.el` via [MELPA](https://melpa.org/#/getting-started).
+  * Check the MELPA's link and add the package archive if you don't set yet
   * `M-x list-packages`  opens the list of all packages (M is the emacs name for Alt)
   * `C-s nim-mode`       moves cursor to nim mode
   * `ESC`                ends search
@@ -12,56 +31,97 @@ nim-mode
   * `x`                  executes install
   * `y`                  to confirm question
 
+Please take a look next `Nimsuggest` section if you interested in
+editor integration like completion, jump-to-definition, or linting.
+
 ## Nimsuggest
+(if you are impatient, skip until `install nimsuggest` to install it)
 
-In nim-mode repository, some *.el files depend on
-[nimsuggest](https://github.com/nim-lang/nimsuggest) (not
-nim-suggest.el), so if you want to use more integration in Emacs,
-please visit the link to install nimsuggest.
+Nimsuggest is an editor agnostic tool for Nim and nim-mode provides:
 
-Brief descriptions for the nimsuggest related files:
-  1. company-nim.el: auto completion feature
-  2. nim-thing-at-point.el: thing-at-point for nim
-  3. nim-eldoc: show information in minibuffer
-  4. flycheck-nimsuggest: lint current file asynchronously
-     (only support .nim files currently)
+1. Completion feature -- `M-/` key and auto-complete if you install
+   [company-mode](https://github.com/company-mode/company-mode)
+2. Asynchronous linting -- (1)
+3. Showing info under the cursor in minibuffer -- (1)
+4. Jump to definition feature -- `M-.` for go to def and `M-,` for
+   back to before the go to def position
 
-Normally it would be enough to install nimsuggest with `nimble install nimsuggest`, but currently nim-mode only support specific install way. (Nim 0.14.02 + nimsuggest at 9c8db4b)
+(1): those are automatically turned on if you turned on `nimsuggest-mode`
+
+### install nimsuggest
+
+Normally it would be enough to install nimsuggest with `nimble install
+nimsuggest`, but due to Nim's rapid development process currently
+nim-mode only support specific install ways.
 
 
-```sh
-# use nim version v0.14.02
-cd /path/to/nim_repository
-git checkout tags/0.14.02
-git clone --depth 1 https://github.com/nim-lang/csources
-cd csources && sh build.sh
-cd ..
-bin/nim c koch && ./koch boot -d:release
+1. Use stable version (Nim 0.14.02 + nimsuggest at 9c8db4b):
 
-# build nimsuggest
-cd /path/to/nimsuggest_repository
-git checkout 9c8db4b
-nim e compile_without_nimble.nims
-```
+   * Install nim either by the
+     [official download](http://nim-lang.org/download.html) or your
+     systems package manager if available.
 
-After you install nimsuggest, you may need following configuration in your emacs configuration file to use nimsuggest properly:
+    Or using git
+
+   ```sh
+   git clone https://github.com/nim-lang/Nim.git
+   cd /path/to/nim_repository
+   git checkout tags/0.14.02
+   git clone --depth 1 https://github.com/nim-lang/csources
+   cd csources && sh build.sh
+   cd ..
+   bin/nim c koch && ./koch boot -d:release
+   ```
+
+   and then install & build nimsuggest
+
+   ```sh
+   git clone https://github.com/nim-lang/nimsuggest.git
+   cd /path/to/nimsuggest_repository
+   git checkout 9c8db4b
+   nim e compile_without_nimble.nims
+
+   ```
+
+2. Use latest version:
+   This way may or may not work (depending on Nim or nimsuggest's
+   state and we can't support all the way), so use above way
+   if you prefer stable.
+   ```sh
+   git clone https://github.com/nim-lang/nimsuggest.git
+   cd /path/to/nimsuggest_repository
+   nim e compile_without_nimble.nims
+   ```
+
+After you installed nimsuggest, you may need following configuration in
+your emacs configuration file (e.g, ~/.emacs.d/init.el):
 
 ```el
 (setq nim-nimsuggest-path "path/to/nimsuggest")
+;; Currently nimsuggest doesn't support nimscript files, so only nim-mode...
+(add-hook 'nim-mode-hook 'nimsuggest-mode)
+;; if you installed company-mode (optional)
+(add-hook 'nim-mode-hook 'company-mode)
+(add-hook 'nimscript-mode-hook 'company-mode)
+;; or use below instead if you want to activate `company-mode` all programming
+;; related modes.
+;; (add-hook 'prog-mode-hook 'company-mode)
 ```
 
 Note that above `nim-nimsuggest-path` variable is automatically set
-the result of `(executable-find "nimsuggest")`, so if you can get value from the `executable-find`, you might don't need above configuration.
+the result of `(executable-find "nimsuggest")`, so if you can get
+value from the `executable-find`, you may not need this
+configuration unless you want to set specific version of nimsuggest.
 
-## company-mode
-If you use `company-mode` then add `company-nim` to `company-backends` like:
-```el
-(add-to-list 'company-backends
-               '(company-nim :with company-nim-builtin))
-```
+## Other convenience packages for editing Nim source code
 
-## nim-eldoc
-This feature is automatically turned on if `nim-suggest-path` is non-nil.
+Those packages are convenience packages and can be installed same way
+as nim-mode (M-x list-packages ...)
+
+- [indent-guide](https://github.com/zk-phi/indent-guide): show visible indent levels
+- [quickrun](https://github.com/syohex/emacs-quickrun):
+- [company-mode](https://github.com/company-mode/company-mode): auto-complete feature
+- [ob-nim](https://github.com/Lompik/ob-nim): org-mode integration focused on Nim
 
 ## auto-indent mode
 If you use `auto-indent-mode`, you need to add nim-mode to the list of
@@ -75,7 +135,3 @@ nim-mode refers to `comment-style` variable which comment style user
 preferred (whether single line or multi line comment) when user invokes
 `comment-region` or `comment-dwim`. See also `comment-styles` variable
 for available options.
-
-## Other convenience packages
-- [indent-guide](https://github.com/zk-phi/indent-guide)
-- [quickrun](https://github.com/syohex/emacs-quickrun)

--- a/company-nim.el
+++ b/company-nim.el
@@ -1,254 +1,37 @@
-;;; company-nim.el --- company backend for nim -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015  Simon Hafner
+;;; Commentary
 
-;; Author: Simon Hafner
-;; Maintainer: Simon Hafner <hafnersimon@gmail.com>
-;; Package-Version: 0.2.0
-;; Package-Requires: ((company "0.8.10") (nim-mode "0.2.0"))
-;; Keywords: convenience
-
-;; This program is free software; you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-;;; Commentary:
-
-;; It contains company backend with nimsuggest support.
-;; You have to add it to company-backends like:
+;; please delete following configuration. Those are no longer required.
 ;;
 ;; (add-to-list 'company-backends
-;;                '(company-nim :with company-nim-builtin))
+;;               '(company-nim :with company-nim-builtin))
 ;;
-;; Also you should add company mode to nim-mode
+;; company-mode support is done using completion-at-point, which is
+;; Emacs’s default feature. (file is nim-capf.el)
 ;;
-;; (add-hook 'nim-mode-hook 'company-mode)
-
-
 ;;; Code:
 
-(require 'epc)
-(require 'nim-mode)
-(require 'company)
-(require 'cl-lib)
+(make-obsolete-variable
+ 'company-nim nil
+ "please check README page, but no harm for deleting this variable")
 
-(defcustom company-nim-type-abbrevs '(("skProc"         . "f")
-                                      ("skIterator"     . "i")
-                                      ("skTemplate"     . "T")
-                                      ("skType"         . "t")
-                                      ("skMethod"       . "f")
-                                      ("skEnumField"    . "e")
-                                      ("skGenericParam" . "p")
-                                      ("skParam"        . "p")
-                                      ("skModule"       . "m")
-                                      ("skConverter"    . "C")
-                                      ("skMacro"        . "M")
-                                      ("skField"        . "F")
-                                      ("skForVar"       . "v")
-                                      ("skVar"          . "v")
-                                      ("skLet"          . "v")
-                                      ("skLabel"        . "l")
-                                      ("skConst"        . "c")
-                                      ("skResult"       . "r"))
-  "Abbrevs for nim-mode (used by company)."
-  :type 'assoc
-  :group 'nim)
+(make-obsolete-variable
+ 'company-nim-builtin nil
+ "please check README page, but no harm for deleting this variable")
 
+(define-obsolete-function-alias 'company-nim nil ""
+  "please delete related configuration to ‘company-nim’.
+This is no longer required for company-mode.")
 
-(defun company-nim--format-candidate (cand)
-  "Formats candidate for company, attaches properties to text."
-  (propertize
-   (car (last (nim-epc-qualifiedPath cand)))
-   :nim-location-line (nim-epc-line cand)
-   :nim-location-column (nim-epc-column cand)
-   :nim-type (nim-epc-forth cand)
-   :nim-doc (nim-epc-doc cand)
-   :nim-file (nim-epc-filePath cand)
-   :nim-sk (nim-epc-symkind cand)
-   :nim-sig (assoc-default (nim-epc-symkind cand) company-nim-type-abbrevs)))
-
-(defun company-nim--format-candidates (arg candidates)
-  "Filters candidates, and returns formatted candadates lists."
-  (mapcar #'company-nim--format-candidate
-          (if (string-equal arg ".")
-              candidates
-            (cl-remove-if-not
-             (lambda (c)
-               (company-nim-fuzzy-match
-                arg
-                (let ((name (car (last (nim-epc-qualifiedPath c)))))
-                  (format "%s%s"
-                          (substring name 0 1)
-                          (downcase (substring name 1 (length name)))))))
-             candidates))))
-
-(defun company-nim-candidates (arg callback)
-  (when (derived-mode-p 'nim-mode)
-    (nim-call-epc
-     'sug
-     (lambda (x) (funcall callback (company-nim--format-candidates arg x))))))
-
-
-(defun company-nim-prefix (&optional use-dotty-syntax)
-  "Return prefix string for completion.
-Or return stop symbol to continue auto-completion using other
-‘company-backends’.  If USE-DOTTY-SYNTAX is non-nil, use
- ‘nim-dotty-syntax-table’ to get string at point."
-  (when (derived-mode-p 'nim-mode)
-    (let (thing)
-      (if (and (not (company-in-string-or-comment))
-               ;; ignore auto-completion when point is empty string
-               ;; (but you can activate manually)
-               (or this-command
-                   (and (string< "" thing)
-                        ;; Stop completion at beginning of word
-                        (not (eq ?\s (char-before)))))
-               (setq thing
-                     (substring-no-properties
-                      (if use-dotty-syntax
-                          ;; grab dot included symbol like XXX.YYY
-                          (with-syntax-table nim-dotty-syntax-table
-                            (company-grab-symbol))
-                        (company-grab-symbol)))))
-          (cons thing t)
-        'stop))))
-
-(defun company-nim-annotation (cand)
-  (let ((ann (get-text-property 0 :nim-type cand))
-        (symbol (get-text-property 0 :nim-sig cand)))
-    (format " %s [%s]" (substring ann 0 (cl-search "{" ann)) symbol)))
-
-;; :nim-type is frequently way too big to display in meta
-;; (defun company-nim-meta (cand)
-;;   (let ((doc (get-text-property 0 :nim-doc cand)))
-;;     (if (eq doc "")
-;;         (get-text-property 0 :nim-type cand)
-;;       doc)))
-
-(defun company-nim-meta (cand)
-  (get-text-property 0 :nim-type cand))
-
-
-(defun company-nim-doc-buffer (cand)
-  (let ((doc
-         (get-text-property 0 :nim-doc cand)))
-    (and (not (eq doc "")) (nim-doc-buffer cand))))
-
-(defun nim-doc-buffer (element)
-  "Displays documentation buffer with ELEMENT contents."
-  (let ((buf (get-buffer-create "*nim-doc*")))
-    (with-current-buffer buf
-      (view-mode -1)
-      (erase-buffer)
-      (insert (get-text-property 0 :nim-doc element))
-      (goto-char (point-min))
-      (view-mode 1)
-      buf)))
-
-(defun company-nim-location (cand)
-  (let ((line (get-text-property 0 :nim-location-line cand))
-        (path (get-text-property 0 :nim-file cand)))
-    (cons path line)))
-
-
-(defun company-nim-fuzzy-match (prefix candidate)
-  "Basic fuzzy match for completions."
-  (cl-subsetp (string-to-list prefix)
-              (string-to-list candidate)))
-
-;;;###autoload
-(defun company-nim (command &optional arg &rest ignored)
-  "`company-mode` backend for nimsuggest."
-  (interactive (list 'interactive))
-  (cl-case command
-    (interactive (company-begin-backend 'company-nim))
-    (prefix (company-nim-prefix))
-    (annotation (company-nim-annotation arg))
-    (doc-buffer (company-nim-doc-buffer arg))
-    (meta (company-nim-meta arg))
-    (location (company-nim-location arg))
-    (candidates (cons :async (lambda (cb) (company-nim-candidates arg cb))))
-    (ignore-case t)
-    (sorted t)))
-
-(defun company-nim-builtin-prefix (arg)
-  (let ((prefix (company-nim-prefix t))
-        (thing (or arg "")))
-    (if (and (not 'stop)
-             (or (equal "" thing) (not (string-match "\\." thing))))
-        prefix
-      'stop)))
-
-;;;###autoload
-(defun company-nim-builtin (command &optional arg &rest ignored)
-  "`company-mode` backend for Nim’s primitive functions."
-  (interactive (list 'interactive))
-  (cl-case command
-    (interactive (company-begin-backend 'company-nim-builtin))
-    (prefix (company-nim-builtin-prefix arg))
-    (annotation (company-nim-annotation arg))
-    (doc-buffer (company-nim-doc-buffer arg))
-    (meta (company-nim-meta arg))
-    (location (company-nim-location arg))
-    ;; TODO: use company-flx (fuzzy match library)
-    (candidates
-     (all-completions
-      arg
-      (company-nim--format-candidates
-       arg (company-nim-get-builtin-candidates))
-      (lambda (candidate)
-        ;; Only first char is case sensitive in Nim and
-        ;; I think it’s convenience to distinguish between normal
-        ;; procs and types. (types often use capitalized character, so)
-        (if (string< "" arg)
-            (eq (string-to-char arg) (string-to-char candidate))
-          t))))
-    (ignore-case t)
-    (sorted t)))
-
-(defvar company-nim--builtin-cache nil)
-(defvar company-nimscript--builtin-cache nil)
-
-(defun company-nim-get-options ()
-  (append nim-suggest-options nim-suggest-local-options))
-
-(defun company-nim-get-builtin-candidates ()
-  "Get candidates based on system.nim."
-  (when (derived-mode-p 'nim-mode)
-    (let ((cache-sym (cl-case major-mode
-                       (nim-mode 'company-nim--builtin-cache)
-                       (nimscript-mode 'company-nimscript--builtin-cache))))
-      (or
-       ;; Use cached data, which corresponds to ‘company-nim-get-options’
-       (cl-loop for (option suggest) in (symbol-value cache-sym)
-                if (equal (cdr option) (company-nim-get-options))
-                do (cl-return (cdr suggest)))
-       ;; Save data asynchronously
-       (save-excursion
-         (add-to-list cache-sym
-                      (list (cons 'option (company-nim-get-options))
-                            (cons 'suggest nil)))
-         (insert " system.")
-         (nim-call-epc
-          'sug
-          `(lambda (suggests)
-             (cl-loop for i from 0 to (1- (length ,cache-sym))
-                      for c = (nth i ,cache-sym)
-                      if (and (equal (cdar c) (company-nim-get-options))
-                              (eq (cdadr c) nil))
-                      do (setf (cdadr (nth i ,cache-sym))
-                               suggests))))
-         (delete-char (- (length " system."))))))))
+(define-obsolete-function-alias 'company-nim-builtin nil ""
+  "please delete related configuration to ‘company-nim-builtin’.
+This is no longer required for company-mode.")
 
 (provide 'company-nim)
+
+;; Local Variables:
+;; coding: utf-8
+;; mode: emacs-lisp
+;; End:
 
 ;;; company-nim.el ends here

--- a/company-nim.el
+++ b/company-nim.el
@@ -11,19 +11,11 @@
 ;;
 ;;; Code:
 
-(make-obsolete-variable
- 'company-nim nil
- "please check README page, but no harm for deleting this variable")
-
-(make-obsolete-variable
- 'company-nim-builtin nil
- "please check README page, but no harm for deleting this variable")
-
-(define-obsolete-function-alias 'company-nim nil ""
+(define-obsolete-function-alias 'company-nim 'ignore
   "please delete related configuration to ‘company-nim’.
 This is no longer required for company-mode.")
 
-(define-obsolete-function-alias 'company-nim-builtin nil ""
+(define-obsolete-function-alias 'company-nim-builtin 'ignore
   "please delete related configuration to ‘company-nim-builtin’.
 This is no longer required for company-mode.")
 

--- a/flycheck-nimsuggest.el
+++ b/flycheck-nimsuggest.el
@@ -29,7 +29,9 @@
 
 (require 'flycheck)
 (require 'cl-lib)
-(require 'nim-suggest)
+
+(autoload 'nim-call-epc "nim-suggest")
+(autoload 'nim-suggest-available-p "nim-suggest")
 
 (defvar flycheck-nimsuggest-patterns
   (mapcar (lambda (p)
@@ -66,6 +68,13 @@ CALLBACK is the status callback passed by Flycheck."
          (error (funcall callback 'errored err)))))))
 
 ;;;###autoload
+(defun flycheck-nimsuggest-setup ()
+  "Setup flycheck configuration for nimsuggest."
+  (when (and (bound-and-true-p nim-use-flycheck-nimsuggest)
+             (not flycheck-checker))
+    (flycheck-select-checker 'nim-nimsuggest)))
+
+;;;###autoload
 (eval-after-load "flycheck"
   '(progn
      (flycheck-define-generic-checker 'nim-nimsuggest
@@ -74,8 +83,9 @@ CALLBACK is the status callback passed by Flycheck."
 See URL `https://github.com/nim-lang/nimsuggest'."
        :start 'flycheck-nim-nimsuggest-start
        :modes '(nim-mode nimscript-mode)
-       :predicate (lambda () (and (nim-suggest-available-p)
-                             nim-use-flycheck-nimsuggest)))
+       :predicate (lambda () (and
+                         (bound-and-true-p nim-use-flycheck-nimsuggest)
+                         (nim-suggest-available-p))))
 
      (add-to-list 'flycheck-checkers 'nim-nimsuggest)))
 

--- a/flycheck-nimsuggest.el
+++ b/flycheck-nimsuggest.el
@@ -1,6 +1,6 @@
 ;;; flycheck-nimsuggest.el --- Yet another flycheck plugin for Nim language -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2016-2017 by Yuta Yamada
+;; Copyright (C) 2016 by Yuta Yamada
 
 ;; Author: Yuta Yamada <cokesboy"at"gmail.com>
 
@@ -21,13 +21,6 @@
 ;;; Commentary:
 
 ;; On the fly syntax check support using Nimsuggest and flycheck.el.
-
-;; This plugin needs this nimsuggest:
-;;   https://github.com/nim-lang/nimsuggest/pull/22
-
-;; TODO: add README how to use
-;; so far I implemented this package automatically turned on if user
-;; satisfied ‘nim-suggest-available-p’, but it may need users’ feedback.
 
 ;; memo:
 ;; https://github.com/lunaryorn/blog/blob/master/posts/generic-syntax-checkers-in-flycheck.md
@@ -78,7 +71,7 @@ CALLBACK is the status callback passed by Flycheck."
      (flycheck-define-generic-checker 'nim-nimsuggest
        "A syntax checker for Nim lang using nimsuggest.
 
-See URL `'."
+See URL `https://github.com/nim-lang/nimsuggest'."
        :start 'flycheck-nim-nimsuggest-start
        :modes '(nim-mode nimscript-mode)
        :predicate (lambda () (and (nim-suggest-available-p)

--- a/nim-capf.el
+++ b/nim-capf.el
@@ -140,6 +140,7 @@ If SKIP is non-nil, skip length check ."
       (let* ((bounds (bounds-of-thing-at-point 'symbol))
              (beg (or (car bounds) (point)))
              (end (or (cdr bounds) (point)))
+             (c-beg (char-after beg))
              ;; avoid length check if previous char is "."
              (skip-len-check (and (not (bobp)) (eq ?. (char-before (point))))))
         (list beg end
@@ -152,7 +153,17 @@ If SKIP is non-nil, skip length check ."
               ;; replacement of company's :post-completion
               :exit-function #'nim-capf--exit-function
               ;; default property of ‘completion-at-point-functions’
-              :exclusive 'no)))))
+              :exclusive 'no
+              :predicate `(lambda (candidate)
+                            (if ,(< 65 c-beg 90) ; whether A-Z
+                                (let ((thing (thing-at-point 'symbol)))
+                                  (if thing
+                                      ;; If user inputs capitalized string,
+                                      ;; check only the first char.
+                                      (eq ,c-beg (string-to-char candidate))
+                                    ;; let default predicate function
+                                    t))
+                              t)))))))
 
 (defun nim-suggest-complete (prefix)
   "Completion symbol of PREFIX at point using nimsuggest."

--- a/nim-capf.el
+++ b/nim-capf.el
@@ -201,6 +201,9 @@ PREFIX is passed to async callback."
           (append nimscript-builtins
                   nimscript-variables)))
 
+(defvar nim-capf--pragma-words
+  (cl-loop for (_ . kwds) in nim-pragmas append kwds))
+
 (defun nim-capf--static-completion (words)
   "Return list of completion-at-point’s elements.
 List of WORDS are used as completion candidates."
@@ -216,7 +219,10 @@ List of WORDS are used as completion candidates."
 ;;;###autoload
 (defun nim-builtin-completion-at-point ()
   "Complete the symbol at point for .nim files."
-  (nim-capf--static-completion nim-capf-builtin-words))
+  (nim-capf--static-completion
+   (if (nim-inside-pragma-p)
+       nim-capf--pragma-words
+     nim-capf-builtin-words)))
 
 ;;;###autoload
 (defun nimscript-builtin-completion-at-point ()

--- a/nim-capf.el
+++ b/nim-capf.el
@@ -133,7 +133,7 @@ If SKIP is non-nil, skip length check ."
     (cons path line)))
 
 ;;;###autoload
-(defun nim-suggest-completion-at-point ()
+(defun nim-capf-nimsuggest-completion-at-point ()
   "Complete the symbol at point using nimsuggest."
   (when nimsuggest-mode
     (unless (nth 3 (syntax-ppss)) ;; not in string
@@ -144,7 +144,7 @@ If SKIP is non-nil, skip length check ."
              ;; avoid length check if previous char is "."
              (skip-len-check (and (not (bobp)) (eq ?. (char-before (point))))))
         (list beg end
-              (completion-table-with-cache 'nim-suggest-complete)
+              (completion-table-with-cache 'nim-capf--nimsuggest-complete)
               :annotation-function #'nim-capf--annotation
               :company-prefix-length (nim-capf--prefix-p beg end skip-len-check)
               :company-docsig #'nim-capf--docsig
@@ -165,7 +165,7 @@ If SKIP is non-nil, skip length check ."
                                     t))
                               t)))))))
 
-(defun nim-suggest-complete (prefix)
+(defun nim-capf--nimsuggest-complete (prefix)
   "Completion symbol of PREFIX at point using nimsuggest."
   (unless (or (nim-inside-pragma-p)
               (nim-syntax-comment-or-string-p))
@@ -230,8 +230,10 @@ See also `completion-extra-properties' to check possible STATUS."
           (append nimscript-builtins
                   nimscript-variables)))
 
-(defvar nim-capf--pragma-words
-  (cl-loop for (_ . kwds) in nim-pragmas append kwds))
+;; use defvar here in case if users want to add theirs
+(defvar nim-capf-pragmas
+  (cl-loop for (_ . kwds) in nim-pragmas append kwds)
+  "List of pragmas for `complietion-at-point-functions'.")
 
 (defun nim-capf--static-completion (words)
   "Return list of completion-at-point’s elements.
@@ -250,7 +252,7 @@ List of WORDS are used as completion candidates."
   "Complete the symbol at point for .nim files."
   (nim-capf--static-completion
    (if (nim-inside-pragma-p)
-       nim-capf--pragma-words
+       nim-capf-pragmas
      nim-capf-builtin-words)))
 
 ;;;###autoload
@@ -268,8 +270,8 @@ List of WORDS are used as completion candidates."
     ;; Don’t change order here
     (unless (memq capf completion-at-point-functions)
       (add-hook 'completion-at-point-functions capf))
-    (unless (memq 'nim-suggest-completion-at-point completion-at-point-functions)
-      (add-hook 'completion-at-point-functions 'nim-suggest-completion-at-point))))
+    (unless (memq 'nim-capf-nimsuggest-completion-at-point completion-at-point-functions)
+      (add-hook 'completion-at-point-functions 'nim-capf-nimsuggest-completion-at-point))))
 
 (provide 'nim-capf)
 

--- a/nim-capf.el
+++ b/nim-capf.el
@@ -1,0 +1,246 @@
+;;; nim-capf.el --- Implementation of Completion At Point Function for nim-mode -*- lexical-binding: t -*-
+
+;; Copyright (C) 2016  Yuta Yamada
+
+;; Author: Yuta Yamada <cokesboy"at"gmail.com>
+;; Keywords: completion
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides Completion At Point Function future (capf in short).
+
+;; Also capf allows you to work with company-mode without adding
+;; backends.
+
+;; TODO: make sure with company-flx package (fuzzy match)
+;;   (https://github.com/PythonNut/company-flx)
+;; memo:
+;;   http://emacs.stackexchange.com/questions/15276/how-do-i-write-a-simple-completion-at-point-functions-function
+;;
+;;; Code:
+
+(require 'let-alist)
+(require 'nim-syntax)
+(require 'nim-suggest)
+
+(defcustom nim-capf--type-abbrevs '(("skProc"         . "f")
+                                    ("skIterator"     . "i")
+                                    ("skTemplate"     . "T")
+                                    ("skType"         . "t")
+                                    ("skMethod"       . "f")
+                                    ("skEnumField"    . "e")
+                                    ("skGenericParam" . "p")
+                                    ("skParam"        . "p")
+                                    ("skModule"       . "m")
+                                    ("skConverter"    . "C")
+                                    ("skMacro"        . "M")
+                                    ("skField"        . "F")
+                                    ("skForVar"       . "v")
+                                    ("skVar"          . "v")
+                                    ("skLet"          . "v")
+                                    ("skLabel"        . "l")
+                                    ("skConst"        . "c")
+                                    ("skResult"       . "r"))
+  "Abbrevs for completion."
+  :type 'assoc
+  :group 'nim)
+
+(defun nim-capf--format-candidate (cand)
+  "Put text property to CAND."
+  (propertize
+   (car (last (nim-epc-qualifiedPath cand)))
+   :nim-line   (nim-epc-line     cand)
+   :nim-column (nim-epc-column   cand)
+   :nim-type   (nim-epc-forth    cand)
+   :nim-doc    (nim-epc-doc      cand)
+   :nim-file   (nim-epc-filePath cand)
+   :nim-sk     (nim-epc-symkind  cand)
+   :nim-sig    (assoc-default
+                (nim-epc-symkind cand) nim-capf--type-abbrevs)))
+
+(defun nim-capf--format-candidates (_arg candidates)
+  "Put text attributes to CANDIDATES."
+  (mapcar #'nim-capf--format-candidate candidates))
+
+(defun nim-capf--nimsuggest-async (prefix callback)
+  "Query to nimsuggest asynchronously.
+
+The PREFIX is passed to the CALLBACK."
+  ;; currently only support nim-mode (not nimscript-mode)
+  (when (derived-mode-p 'nim-mode)
+    (nim-call-epc
+     'sug
+     (lambda (x) (funcall callback (nim-capf--format-candidates prefix x))))))
+
+(defun nim-capf--prefix-p (beg end &optional skip)
+  "Return t if completion should be triggered for prefix between BEG and END.
+If SKIP is non-nil, skip length check ."
+  (and
+   (if (or skip (eq this-command 'company-idle-begin))
+       t
+     (let ((diff (- end beg))
+           (len (bound-and-true-p company-minimum-prefix-length)))
+       (and len (<= len diff))))
+   (<= beg end)
+   (or (eolp)
+       (let ((c-end (char-after end)))
+         (and c-end (not (eq ?w (char-syntax c-end))))))))
+
+(defun nim-capf--annotation (cand)
+  "Get annotation info for CAND."
+  (let ((ann (get-text-property 0 :nim-type cand))
+        (symbol (get-text-property 0 :nim-sig cand)))
+    (format " %s [%s]" (substring ann 0 (cl-search "{" ann)) symbol)))
+
+(defun nim-capf--docsig (cand)
+  "Get docsig info for CAND."
+  (get-text-property 0 :nim-type cand))
+
+(defun nim-capf--doc-buffer (cand)
+  "Get doc-buffer info for CAND."
+  (let ((doc (get-text-property 0 :nim-doc cand)))
+    (unless (equal doc "")
+      (nim-capf--doc-buffer-core cand))))
+
+(defun nim-capf--doc-buffer-core (element)
+  "Displays documentation buffer with ELEMENT contents."
+  (let ((buf (get-buffer-create "*nim-doc*")))
+    (with-current-buffer buf
+      (view-mode -1)
+      (erase-buffer)
+      (insert (get-text-property 0 :nim-doc element))
+      (goto-char (point-min))
+      (view-mode 1)
+      buf)))
+
+(defun nim-capf--location (cand)
+  "Get location info for CAND."
+  (let ((line (get-text-property 0 :nim-line cand))
+        (path (get-text-property 0 :nim-file cand)))
+    (cons path line)))
+
+;;;###autoload
+(defun nim-suggest-completion-at-point ()
+  "Complete the symbol at point using nimsuggest."
+  (when nimsuggest-mode
+    (unless (nth 3 (syntax-ppss)) ;; not in string
+      (let* ((bounds (bounds-of-thing-at-point 'symbol))
+             (beg (or (car bounds) (point)))
+             (end (or (cdr bounds) (point)))
+             ;; avoid length check if previous char is "."
+             (skip-len-check (and (not (bobp)) (eq ?. (char-before (point))))))
+        (list beg end
+              (completion-table-with-cache 'nim-suggest-complete)
+              :annotation-function #'nim-capf--annotation
+              :company-prefix-length (nim-capf--prefix-p beg end skip-len-check)
+              :company-docsig #'nim-capf--docsig
+              :company-doc-buffer #'nim-capf--doc-buffer
+              :company-location #'nim-capf--location
+              ;; not sure what is the best option
+              ;; :company-require-match company-require-match
+              ;; default property of ‘completion-at-point-functions’
+              :exclusive 'no)))))
+
+(defun nim-suggest-complete (prefix)
+  "Completion symbol of PREFIX at point using nimsuggest."
+  (unless (or (nim-inside-pragma-p)
+              (nim-syntax-comment-or-string-p))
+    (cond
+     ((or (string< "" prefix)
+          (eq ?. (char-before (point))))
+      (nim-capf--update prefix)))))
+
+(defun nim-capf--update (prefix)
+  "Query completion to nimsuggest.
+PREFIX is passed to async callback."
+  (let* ((buf (current-buffer))
+         (start (time-to-seconds))
+         (res 'trash))
+    (nim-capf--nimsuggest-async
+     prefix
+     (lambda (candidates)
+       (when (eq (current-buffer) buf)
+         (setq res candidates))))
+    (while (and (eq 'trash res) (eq (current-buffer) buf))
+      (if (> (- (time-to-seconds) start) 2)
+          (error "Nimsuggest completion: timeout %d sec" 2)
+        (sleep-for 0.03)))
+    (unless (eq 'trash res)
+      res)))
+
+;; completion at point
+(defun nim-capf-builtin-completion ()
+  "This might not be precise, but maybe enough to someone."
+  (append nim-keywords
+          nim-types
+          nim-exceptions
+          nim-variables
+          nim-constants
+          nim-nonoverloadable-builtins
+          nim-builtins))
+
+(defconst nim-capf-builtin-words
+  (append (nim-capf-builtin-completion)
+          nim-builtins-without-nimscript))
+
+(defconst nim-capf-builtin-words-nimscript
+  (append (nim-capf-builtin-completion)
+          (append nimscript-builtins
+                  nimscript-variables)))
+
+(defun nim-capf--static-completion (words)
+  "Return list of completion-at-point’s elements.
+List of WORDS are used as completion candidates."
+  (unless (nth 3 (syntax-ppss)) ;; not in string
+    (when (or this-command (thing-at-point 'symbol))
+      (let* ((bounds (bounds-of-thing-at-point 'symbol))
+           (beg (or (car bounds) (point)))
+           (end (or (cdr bounds) (point))))
+      (list beg end words
+            :company-prefix-length (nim-capf--prefix-p beg end)
+            :exclusive 'no)))))
+
+;;;###autoload
+(defun nim-builtin-completion-at-point ()
+  "Complete the symbol at point for .nim files."
+  (nim-capf--static-completion nim-capf-builtin-words))
+
+;;;###autoload
+(defun nimscript-builtin-completion-at-point ()
+  "Complete the symbol at point for nimscript files."
+  (nim-capf--static-completion nim-capf-builtin-words-nimscript))
+
+;;;###autoload
+(defun nim-capf-setup ()
+  "Setup."
+  (let ((capf (cl-case major-mode
+                (nim-mode       'nim-builtin-completion-at-point)
+                (nimscript-mode 'nimscript-builtin-completion-at-point)
+                (t (error "Unexpected major mode")))))
+    ;; Don’t change order here
+    (unless (memq capf completion-at-point-functions)
+      (add-hook 'completion-at-point-functions capf))
+    (unless (memq 'nim-suggest-completion-at-point completion-at-point-functions)
+      (add-hook 'completion-at-point-functions 'nim-suggest-completion-at-point))))
+
+(provide 'nim-capf)
+
+;; Local Variables:
+;; coding: utf-8
+;; mode: emacs-lisp
+;; End:
+
+;;; nim-capf.el ends here

--- a/nim-capf.el
+++ b/nim-capf.el
@@ -155,7 +155,7 @@ If SKIP is non-nil, skip length check ."
               ;; default property of ‘completion-at-point-functions’
               :exclusive 'no
               :predicate `(lambda (candidate)
-                            (if ,(< 65 c-beg 90) ; whether A-Z
+                            (if ,(and c-beg (< 65 c-beg 90)) ; whether A-Z
                                 (let ((thing (thing-at-point 'symbol)))
                                   (if thing
                                       ;; If user inputs capitalized string,

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -186,18 +186,8 @@ DEFS is group of definitions from nimsuggest."
                        finally return 0)))
         (substring short-str 0 (- (length short-str) minus-offset))))))
 
-;;;###autoload
-(defun nim-eldoc-setup ()
-  "Setup eldoc configuration for nim-mode."
-  (when (and (derived-mode-p 'nim-mode) (nim-suggest-available-p)
-             (or (bound-and-true-p eldoc-mode)
-                 (bound-and-true-p global-eldoc-mode)))
-    (message "nim-mode: eldoc feature turned on automatically")
-    (add-function :before-until (local 'eldoc-documentation-function)
-                  #'nim-eldoc-function)))
-
-;;;###autoload
-(add-hook 'nim-common-init-hook 'nim-eldoc-setup)
+;; backward compatibility
+(defalias 'nim-eldoc-setup 'ignore)
 
 (provide 'nim-eldoc)
 ;;; nim-eldoc.el ends here

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -39,6 +39,7 @@
                  symbol-end (0+ " "))
           (group line-start (0+ " ")))))
 
+;;;###autoload
 (defun nim-eldoc-function ()
   "Return a doc string appropriate for the current context, or nil."
   (interactive)

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -20,7 +20,7 @@
 
 ;;; Commentary:
 
-;; Eldoc supports for Nim. This package automatically turns on
+;; Eldoc supports for Nim.  This package automatically turns on
 ;; if you set ‘nim-nimsuggest-path’ and the nimsuggest is working.
 
 ;;; Code:
@@ -44,6 +44,7 @@
   "Return a doc string appropriate for the current context, or nil."
   (interactive)
   (when (and (or (bound-and-true-p eldoc-mode)
+                 ;; This mode was added at Emacs 25
                  (bound-and-true-p global-eldoc-mode))
              (not (eq ?\  (char-after (point)))))
     (unless (nim-eldoc-same-try-p)

--- a/nim-helper.el
+++ b/nim-helper.el
@@ -938,7 +938,7 @@ But, string-face's CHAR is ignored.  If you set POS, the check starts from POS."
 ;; below functions were copied from subr-x.el
 ;; (I tried dash’s -if-let, but unfortunately it didn’t pass tests
 ;; , though not sure why)
-(unless (fboundp 'if-let)
+(unless (or (fboundp 'if-let) (fboundp 'when-let))
   (with-no-warnings ; <- suppress fboudp return value is empty
     (eval-when-compile
       (defmacro internal--thread-argument (first? &rest forms)
@@ -1020,7 +1020,16 @@ to bind a single value, BINDINGS can just be a plain tuple."
         `(let* ,(internal--build-bindings bindings)
            (if ,(car (internal--listify (car (last bindings))))
                ,then
-             ,@else))))))
+             ,@else)))
+
+      (defmacro when-let (bindings &rest body)
+        "Process BINDINGS and if all values are non-nil eval BODY.
+Argument BINDINGS is a list of tuples whose car is a symbol to be
+bound and (optionally) used in BODY, and its cadr is a sexp to be
+evalled to set symbol's value.  In the special case you only want
+to bind a single value, BINDINGS can just be a plain tuple."
+        (declare (indent 1) (debug if-let))
+        (list 'if-let bindings (macroexp-progn body))))))
 
 (provide 'nim-helper)
 ;;; nim-helper.el ends here

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -134,8 +134,7 @@
   (setq-local electric-indent-inhibit t)
   (setq-local electric-indent-chars '(?: ?\s))
   (when electric-indent-mode
-    (add-function :around
-                  (local 'delete-backward-char) 'nim-electric-backspace)))
+    (define-key nim-mode-map [remap delete-backward-char] 'nim-electric-backspace)))
 
 ;; add ‘nim-indent-function’ to electric-indent’s
 ;; blocklist. ‘electric-indent-inhibit’ isn’t enough for old emacs.
@@ -284,7 +283,6 @@ The ARGS are passed to original ‘delete-backward-char’ function."
   (let (back)
     (if (and electric-indent-mode
              (eq (current-indentation) (current-column))
-             (memq last-command-event '(? ?)) ; C-h and backspace
              (called-interactively-p 'interactive)
              (not (nim-syntax-comment-or-string-p))
              (not (bolp))

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -54,7 +54,6 @@
 (require 'paren) ; for ‘show-paren-data-function’
 (require 'nim-fill)
 (require 'nim-compile)
-(require 'nim-suggest)
 (require 'commenter)
 
 (put 'nim-mode 'font-lock-defaults '(nim-font-lock-keywords nil t))

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -277,7 +277,8 @@ the line will be re-indented automatically if needed."
       (indent-line-to next))))
 
 (defun nim-electric-backspace (&rest args)
-  "Delete preceding char or levels of indentation."
+  "Delete preceding char or levels of indentation.
+The ARGS are passed to original ‘delete-backward-char’ function."
   (interactive "p\nP")
   (let (back)
     (if (and electric-indent-mode

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -77,6 +77,7 @@
                 t))
 
   ;; Comment
+  (setq-local comment-style 'indent)
   (setq-local comment-use-syntax t)
   ;; Those start and end comment variables are for initial value.
   (setq-local comment-start "#")

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -7,7 +7,7 @@
 ;; Version: 0.2.0
 ;; Keywords: nim languages
 ;; Compatibility: GNU Emacs 24.4
-;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1") (flycheck "28") (company "0.8.12"))
+;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1") (flycheck "28"))
 ;;
 ;; Taken over from James H. Fisher <jameshfisher@gmail.com>
 ;;
@@ -311,6 +311,11 @@ Argument ARG is ignored."
    "#"
    nim-hideshow-forward-sexp-function
    nil))
+
+;; capf
+(autoload 'nim-capf-setup "nim-capf")
+(add-hook 'nim-mode-hook 'nim-capf-setup)
+(add-hook 'nimscript-mode-hook 'nim-capf-setup)
 
 (provide 'nim-mode)
 

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -216,9 +216,12 @@ Note that this directory is removed when you exit from Emacs.")
         (when (or (bound-and-true-p eldoc-mode)
                   (bound-and-true-p global-eldoc-mode))
           (add-function :before-until (local 'eldoc-documentation-function)
-                        'nim-eldoc-function)))
+                        'nim-eldoc-function))
+        ;; flycheck
+        (flycheck-nimsuggest-setup))
     ;; Turn off
     ;; FIXME: find proper way to turn off flycheck
     (remove-function (local 'eldoc-documentation-function) 'nim-eldoc-function)))
+
 (provide 'nim-suggest)
 ;;; nim-suggest.el ends here

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -198,6 +198,9 @@ Note that this directory is removed when you exit from Emacs.")
        (forward-line (1- (nim-epc-line def)))))))
 (define-obsolete-function-alias 'nim-goto-sym 'nimsuggest-find-definition "2017/9/02")
 
+;; To avoid warning
+(autoload 'flycheck-nimsuggest-setup "flycheck-nimsuggest")
+
 (defvar nimsuggest-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "M-.") #'nimsuggest-find-definition)

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -190,5 +190,20 @@ Note that this directory is removed when you exit from Emacs.")
                     (goto-char (point-min))
                     (forward-line (1- (nim-epc-line def)))))))
 
+;;;###autoload
+(define-minor-mode nimsuggest-mode
+  "Minor mode for nimsuggest."
+  :lighter " nimsuggest"
+  (if nimsuggest-mode
+      ;; Turn on
+      (when (and (derived-mode-p 'nim-mode) (nim-suggest-available-p))
+        ;; EL-DOC
+        (when (or (bound-and-true-p eldoc-mode)
+                  (bound-and-true-p global-eldoc-mode))
+          (add-function :before-until (local 'eldoc-documentation-function)
+                        'nim-eldoc-function)))
+    ;; Turn off
+    ;; FIXME: find proper way to turn off flycheck
+    (remove-function (local 'eldoc-documentation-function) 'nim-eldoc-function)))
 (provide 'nim-suggest)
 ;;; nim-suggest.el ends here

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -365,6 +365,14 @@ character address of the specified TYPE."
                    (eq ?.  (char-after (1+  ppss9-last)))
                    (1+  ppss9-last))))))))
 
+(defvar nim--pragma-regex
+  (let ((pragma (cl-loop for (_ . kwds) in nim-pragmas append kwds)))
+    (apply
+     `((lambda ()
+         (nim-rx (or (group (or (group (? ".") "}")
+                                (group "." (eval (cons 'or (list ,@pragma))))))
+                     (group (eval (cons 'or (list ,@pragma)))))))))))
+
 (defun nim-pragma-matcher (&optional _start-pos)
   "Highlight pragma."
   (nim-matcher-func
@@ -378,10 +386,7 @@ character address of the specified TYPE."
      (unless (nim-inside-pragma-p)
        (throw 'exit nil)))
    (lambda ()
-     (not (re-search-forward
-           (nim-rx (or (group (or (group (? ".") "}")
-                                  (group "." identifier)))
-                       (group identifier))) nil t)))
+     (not (re-search-forward nim--pragma-regex nil t)))
    (lambda (ppss)
      (cond
       ((nth 4 ppss)

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -162,7 +162,6 @@ specific directory or buffer.  See also ‘dir-locals-file’.")
 
 (defvar nim-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "M-.") 'nim-goto-sym)
     (define-key map (kbd "C-c h") 'nim-explain-sym)
     (define-key map (kbd "C-c C-c") 'nim-compile)
     (define-key map "\C-c<" 'nim-indent-shift-left)

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -122,7 +122,7 @@ other tokens like ’:’ or ’=’."
   ;; What character should be default? („…“, “…”, ‘…’, or etc.?)
   (cons ?“ ?”)
   "Change triple double quotes to another quote form.
-This configuration is enabled only in ‘prettify-symbols-mode’."
+This configuration is enabled only in `prettify-symbols-mode`."
   :type 'cons
   :group 'nim)
 

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -120,7 +120,7 @@ other tokens like ’:’ or ’=’."
 
 (defcustom nim-pretty-triple-double-quotes
   ;; What character should be default? („…“, “…”, ‘…’, or etc.?)
-  (cons ?“ ?”)
+  (cons ?„ ?”)
   "Change triple double quotes to another quote form.
 This configuration is enabled only in `prettify-symbols-mode`."
   :type 'cons

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -358,6 +358,36 @@ But all those functions can not use in NimScript.")
   '( "`" "{." ".}" "[" "]" "{" "}" "(" ")" )
   "Nim standard operators.")
 
+(defvar nim-pragmas
+  '(("pragmas.txt"
+     . ("deprecated" "noSideEffect" "destructor" "override"
+        "procvar" "compileTime" "noReturn" "acyclic" "final" "shallow" "pure"
+        "asmNoStackFrame" "error" "fatal" "warning" "hint" "line"
+        "linearScanEnd" "computedGoto" "unroll" "immediate"
+        "register" "global" "deadCodeElim" "noforward" "pragma" "experimental"
+        ;; http://nim-lang.org/docs/manual.html#pragmas-push-and-pop-pragmas
+        "push" "pop"
+        ;; implementation-specific-pragmas section
+        "bitsize" "volatile" "noDecl" "header" "incompleteStruct" "compile" "link"
+        "passL" "emit" "importcpp" "importObjC" "codegenDecl" "injectStmt"
+        "intdefine" "strdefine"
+        ;; compilation option pragmas
+        "checks" "boundChecks" "overflowChecks" "nilChecks" "assertions"
+        "warnings" "hints" "optimization" "patterns" "callconv"))
+    ("procs.txt"
+     ;; iterators-and-the-for-statement-first-class-iterators section
+     . ("inline" "closure"))
+    ("ffi.txt"
+     . ("importc" "exportc" "extern" "bycopy" "byref" "varargs" "union" "packed"
+        "unchecked" "dynlib"))
+    ("threads.txt"
+     . ("thread" "threadvar"))
+    ("locking.txt"
+     . ("guard" "locks"))
+    ("effects.txt"
+     . ("raises" "tags" "effects")))
+  "Predefined pragmas.")
+
 ;; Nimscript
 (defvar nim-nimble-ini-format-regex (rx line-start "[Package]"))
 


### PR DESCRIPTION
Removed company-nim.el and added nim-capf.el instead.
The capf is short of `completion-at-point-functions`, which is Emacs' default
completion feature (`M-/` key) and company-mode also supports this future as `company-capf`.

Also, I added `nimsuggest-mode` minor-mode, which activate nimsuggest related futures (el-doc, capf, flycheck) because sometimes nimsuggest is unstable when you use with nim's devel branch and switching `nimsuggset-mode` might help to distinguish the problem.