### PR TITLE
better stuff

### DIFF
--- a/nim-compile.el
+++ b/nim-compile.el
@@ -82,21 +82,20 @@ The config file would one of those: config.nims, PROJECT.nim.cfg, or nim.cfg."
   (when buffer-file-name
     (let ((file (shell-quote-argument buffer-file-name)))
       (setq-local compile-command
-            (if
-                (eq 'nimscript-mode major-mode)
-                (let ((pfile (nim-get-project-file '(".nims" ".nimble"))))
-                   (cond
-                    ;; as build tool
-                    ((nim-nimble-file-p file)
-                     (let ((nim-compile-command "nimble"))
-                       (nim--fmt '("build") "")))
-                    ((and (nim-nims-file-p pfile)
-                          (equal pfile buffer-file-name))
-                     (nim--fmt '("build") pfile))
-                    (t
-                     ;; as script file
-                     (nim--fmt '("e") file))))
-              (nim--fmt nim-compile-default-command file))))))
+                  (if (eq 'nimscript-mode major-mode)
+                      (let ((pfile (nim-get-project-file '(".nims" ".nimble"))))
+                        (cond
+                         ;; as build tool
+                         ((nim-nimble-file-p file)
+                          (let ((nim-compile-command "nimble"))
+                            (nim--fmt '("build") "")))
+                         ((and (nim-nims-file-p pfile)
+                               (equal pfile buffer-file-name))
+                          (nim--fmt '("build") pfile))
+                         (t
+                          ;; as script file
+                          (nim--fmt '("e") file))))
+                    (nim--fmt nim-compile-default-command file))))))
 
 (defun nim--fmt (args file)
   "Format ARGS and FILE for the nim command into a shell compatible string."

--- a/nim-compile.el
+++ b/nim-compile.el
@@ -16,7 +16,8 @@ Functions (hooks) take one argument as file file string and
 return build command liek ‘nim c -r FILE.nim’")
 
 (defvar nim-compile-default-command
-  '("c" "-r" "--verbosity:0" "--hint[Processing]:off"))
+  '("compile" "-r" "--verbosity:0" "--hint[Processing]:off" "--colors:off" "--excessiveStackTrace:on" "--debugger:native")
+  "Default list of arguments passed to nim when invoking nim-compile.")
 
 ;; MEMO:
 ;; Implemented based on compiler document:

--- a/nim-compile.el
+++ b/nim-compile.el
@@ -110,10 +110,6 @@ The config file would one of those: config.nims, PROJECT.nim.cfg, or nim.cfg."
   "Compile and execute the current buffer as a nim file.  All output is writton into the *compilation* buffer."
   (interactive)
   (when (derived-mode-p 'nim-mode)
-    ;; (add-hook 'compilation-filter-hook 'nim--colorize-compilation-buffer)
-    ;; (add-hook 'compilation-finish-functions 'nim--remove-colorize-hook)
-    ;; (nim-compile--set-compile-command)
-    ;; (funcall 'compile compile-command 'nim-compile-mode)))
     (call-interactively 'compile)))
 
 (require 'ansi-color)

--- a/nim-compile.el
+++ b/nim-compile.el
@@ -49,8 +49,7 @@ The config file would one of those: config.nims, PROJECT.nim.cfg, or nim.cfg."
    nim-config-regex))
 
 (defun nim-find-file-in-heirarchy (current-dir pattern)
-  "Search for a file matching PATTERN upwards through the directory
-hierarchy, starting from CURRENT-DIR"
+  "Search starting from CURRENT-DIR for a file matching PATTERN upwards through the directory hierarchy."
   (catch 'found
     (locate-dominating-file
      current-dir
@@ -82,9 +81,11 @@ hierarchy, starting from CURRENT-DIR"
       (nim--fmt '("build") file))))
 
 (defun nim-nims-file-p (file)
+  "Test if FILE is a nim script file."
   (equal "nims" (file-name-extension file)))
 
 (defun nim-nimble-file-p (file)
+  "Test if FILE is a nimble file."
   (equal "nimble" (file-name-extension file)))
 
 (defun nim-compile--set-compile-command ()
@@ -118,6 +119,7 @@ hierarchy, starting from CURRENT-DIR"
                     cmd)))))
 
 (defun nim--fmt (args file)
+  "Format ARGS and FILE for the nim command into a shell compatible string."
   (mapconcat
    'shell-quote-argument
    (delq nil `(,nim-compile-command ,@args ,@nim-compile-user-args ,file))
@@ -128,6 +130,7 @@ hierarchy, starting from CURRENT-DIR"
 
 ;;;###autoload
 (defun nim-compile ()
+  "Compile and execute the current buffer as a nim file.  All output is writton into the *compilation* buffer."
   (interactive)
   (when (derived-mode-p 'nim-mode)
     (add-hook 'compilation-filter-hook 'nim--colorize-compilation-buffer)

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -311,8 +311,27 @@ Argument ARG is ignored."
    nim-hideshow-forward-sexp-function
    nil))
 
+(add-to-list 'compilation-error-regexp-alist 'nim)
+
+;; \\( \\) groups sub expression
+;; \\(?: \\) group with no backreference (required to apply ? or \\| on more than a single char)
+;; 1 index of subexpression for file
+;; 2 index of subexpression for line number
+;; 3 index of subexpression for column number
+;; (4 . 5) weird emacs magic to detect type of message
+;; when optional subgroup 4 matches, it is a warning
+;; when optional subgroup 5 matches, it is just a message
+;; when none of them match, it is an error
+;; when you want to develop a regular expression, do it with re-builder (very helpful)
+
+(add-to-list
+ 'compilation-error-regexp-alist-alist
+ '(nim "^\\([[:alnum:]\\/_.-]*\\.nims?\\)(\\([[:digit:]]*\\)\\(?:, ?\\([[:digit:]]*\\)\\)?) \\(\\(?:Warning\\)\\|\\(?:Hint\\):\\)?\\(template/generic instantiation from here\\)?\\(?:Error\\)?" 1 2 3 (4 . 5)))
+
+
 ;; capf
 (autoload 'nim-capf-setup "nim-capf")
+
 (add-hook 'nim-mode-hook 'nim-capf-setup)
 (add-hook 'nimscript-mode-hook 'nim-capf-setup)
 

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -118,6 +118,9 @@
   ;; add-log
   (setq-local add-log-current-defun-function #'nim-info-current-defun)
 
+  ;; compiling
+  (nim-compile--set-compile-command)
+
   ;; Hooks
   ;; Add """ ... """ pairing to electric-pair-mode.
   (add-hook 'post-self-insert-hook


### PR DESCRIPTION
basically compilation works better. Instead of providing nim-compile, I just wrote some code that sets some variables accordingly, so that the emacs builtin compile command works out of the box, no new key needs to be bound to anything. I left nim-compile in there, for now, but it just calls compile, nothing else. Also I added a few more regular expressions, so that the compilation buffer has clickable error messages and stack traces.