### PR TITLE
Apply nimsuggest's new error format for chk method #154

### DIFF
--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -15,10 +15,10 @@
 ;;; If you change the order here, make sure to change it over in
 ;;; nimsuggest.nim too.
 (defconst nim-epc-order
-  '(:section :symkind :qualifiedPath :filePath :forth :line :column :doc))
+  '(:section :symkind :qualifiedPath :filePath :forth :line :column :doc :quality))
 
 (cl-defstruct nim-epc
-  section symkind qualifiedPath filePath forth line column doc)
+  section symkind qualifiedPath filePath forth line column doc quality)
 
 (defun nim-parse-epc (obj method)
   "Parse OBJ according to METHOD."


### PR DESCRIPTION
For commit in nim repository: 6c0304f nimsuggest chk works for EPC