### PR TITLE
allow emacs to parse nim error messages from the compilation buffer

### DIFF
--- a/nim-compile.el
+++ b/nim-compile.el
@@ -49,8 +49,7 @@ The config file would one of those: config.nims, PROJECT.nim.cfg, or nim.cfg."
    nim-config-regex))
 
 (defun nim-find-file-in-heirarchy (current-dir pattern)
-  "Search for a file matching PATTERN upwards through the directory
-hierarchy, starting from CURRENT-DIR"
+  "Search starting from CURRENT-DIR for a file matching PATTERN upwards through the directory hierarchy."
   (catch 'found
     (locate-dominating-file
      current-dir
@@ -82,9 +81,11 @@ hierarchy, starting from CURRENT-DIR"
       (nim--fmt '("build") file))))
 
 (defun nim-nims-file-p (file)
+  "Test if FILE is a nim script file."
   (equal "nims" (file-name-extension file)))
 
 (defun nim-nimble-file-p (file)
+  "Test if FILE is a nimble file."
   (equal "nimble" (file-name-extension file)))
 
 (defun nim-compile--set-compile-command ()
@@ -118,6 +119,7 @@ hierarchy, starting from CURRENT-DIR"
                     cmd)))))
 
 (defun nim--fmt (args file)
+  "Format ARGS and FILE for the nim command into a shell compatible string."
   (mapconcat
    'shell-quote-argument
    (delq nil `(,nim-compile-command ,@args ,@nim-compile-user-args ,file))
@@ -132,6 +134,7 @@ hierarchy, starting from CURRENT-DIR"
 
 ;;;###autoload
 (defun nim-compile ()
+  "Compile and execute the current buffer as a nim file.  All output is writton into the *compilation* buffer."
   (interactive)
   (when (derived-mode-p 'nim-mode)
     (nim-compile--set-compile-command)

--- a/nim-compile.el
+++ b/nim-compile.el
@@ -13,10 +13,10 @@
   '(nim-compile--project)
   "Checker functions to decide build command.
 Functions (hooks) take one argument as file file string and
-return build command liek ‘nim c -r FILE.nim’")
+return build command like ‘nim c -r FILE.nim’")
 
 (defvar nim-compile-default-command
-  '("c" "-r" "--verbosity:0" "--hint[Processing]:off"))
+  '("c" "-r" "--verbosity:0" "--hint[Processing]:off" "--excessiveStackTrace:on"))
 
 ;; MEMO:
 ;; Implemented based on compiler document:

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -311,8 +311,27 @@ Argument ARG is ignored."
    nim-hideshow-forward-sexp-function
    nil))
 
+(add-to-list 'compilation-error-regexp-alist 'nim)
+
+;; \\( \\) groups sub expression
+;; \\(?: \\) group with no backreference (required to apply ? or \\| on more than a single char)
+;; 1 index of subexpression for file
+;; 2 index of subexpression for line number
+;; 3 index of subexpression for column number
+;; (4 . 5) weird emacs magic to detect type of message
+;; when optional subgroup 4 matches, it is a warning
+;; when optional subgroup 5 matches, it is just a message
+;; when none of them match, it is an error
+;; when you want to develop a regular expression, do it with re-builder (very helpful)
+
+(add-to-list
+ 'compilation-error-regexp-alist-alist
+ '(nim "^\\([[:alnum:]\\/_.-]*\\.nims?\\)(\\([[:digit:]]*\\)\\(?:, ?\\([[:digit:]]*\\)\\)?) \\(\\(?:Warning\\)\\|\\(?:Hint\\):\\)?\\(template/generic instantiation from here\\)?\\(?:Error\\)?" 1 2 3 (4 . 5)))
+
+
 ;; capf
 (autoload 'nim-capf-setup "nim-capf")
+
 (add-hook 'nim-mode-hook 'nim-capf-setup)
 (add-hook 'nimscript-mode-hook 'nim-capf-setup)
 

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -311,6 +311,8 @@ Argument ARG is ignored."
    nim-hideshow-forward-sexp-function
    nil))
 
+
+;; enable the regular for nim error messages in compilation buffers
 (add-to-list 'compilation-error-regexp-alist 'nim)
 
 ;; \\( \\) groups sub expression
@@ -324,6 +326,7 @@ Argument ARG is ignored."
 ;; when none of them match, it is an error
 ;; when you want to develop a regular expression, do it with re-builder (very helpful)
 
+;; add the regular expression to the list of available regular expressions with the symbol nim
 (add-to-list
  'compilation-error-regexp-alist-alist
  '(nim "^\\([[:alnum:]\\/_.-]*\\.nims?\\)(\\([[:digit:]]*\\)\\(?:, ?\\([[:digit:]]*\\)\\)?)\\( \\(?:Warning\\)\\|\\(?:Hint\\):\\)?\\(template/generic instantiation from here\\)?\\(?: Error\\)?" 1 2 3 (4 . 5)))

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -326,9 +326,7 @@ Argument ARG is ignored."
 
 (add-to-list
  'compilation-error-regexp-alist-alist
- '(nim "^\\([[:alnum:]\\/_.-]*\\.nims?\\)(\\([[:digit:]]*\\)\\(?:, ?\\([[:digit:]]*\\)\\)?) \\(\\(?:Warning\\)\\|\\(?:Hint\\):\\)?\\(template/generic instantiation from here\\)?\\(?:Error\\)?" 1 2 3 (4 . 5)))
-
-
+ '(nim "^\\([[:alnum:]\\/_.-]*\\.nims?\\)(\\([[:digit:]]*\\)\\(?:, ?\\([[:digit:]]*\\)\\)?)\\( \\(?:Warning\\)\\|\\(?:Hint\\):\\)?\\(template/generic instantiation from here\\)?\\(?: Error\\)?" 1 2 3 (4 . 5)))
 ;; capf
 (autoload 'nim-capf-setup "nim-capf")
 


### PR DESCRIPTION
I have this change now already for quite a while in my other pull request that had some controversy because of my changes on how compilation works. This pull request has only the part for parsing the compilation error messages.

I added --excessiveStackTrace:on so that stack traces have absolute paths. This makes clicking on them work more often, when the files are not in the current project.