### PR TITLE
nim-compile fix

### DIFF
--- a/nim-mode.el
+++ b/nim-mode.el
@@ -134,7 +134,11 @@
   (setq-local electric-indent-inhibit t)
   (setq-local electric-indent-chars '(?: ?\s))
   (when electric-indent-mode
-    (define-key nim-mode-map [remap delete-backward-char] 'nim-electric-backspace)))
+    (define-key nim-mode-map [remap delete-backward-char] 'nim-electric-backspace))
+
+
+  ;; Set `compile-command' to the correct initial value
+  (nim-compile--set-compile-command))
 
 ;; add ‘nim-indent-function’ to electric-indent’s
 ;; blocklist. ‘electric-indent-inhibit’ isn’t enough for old emacs.


### PR DESCRIPTION
The logic to evaluate the initial value of `compile-command` in now executed only once for every nim-mode buffer. This allows the function `compile` without arguments to just work on nim files.

`nim-compile` now behaves more like `compile`, it does not "forget" the old value of `compile-command` anymore, but allows to interactively change it.

Overall the value of `compile-command` is a bit more persistent.