### PR TITLE
Support xref library and some refactor

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,16 +25,16 @@ Most of `nim-mode`s features depend on nimsuggest. If you think your issue is
 related to nimsuggest, as a first debug step, see if the problem disappears when
 you disable nimsuggest.
 
-You can turn off nimsuggest by setting `nim-nimsuggest-path` to `nil`:
+You can turn off nimsuggest by setting `nimsuggest-path` to `nil`:
 
 ```lisp
 ;; place this configuration in your .emacs or somewhere before emacs
 ;; load nim-mode and you may need to reboot your Emacs to check.
-(defconst nim-nimsuggest-path nil)
+(defconst nimsuggest-path nil)
 ```
 
 Generally, `nim-mode` uses nimsuggest via `company-mode`, `eldoc-mode`,
-`flycheck-mode`, `nim-thing-at-point`, and `nim-goto-sym` (goto definition).
+`flycheck-mode`, and `nimsuggest-find-definition` (goto definition).
 
 If you are completely new to Emacs, please check next section as well.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ your Emacs configuration file (e.g, ~/.emacs.d/init.el):
 
 ```elisp
 ;; can be optional.  See below note
-(setq nim-nimsuggest-path "path/to/nimsuggest")
+(setq nimsuggest-path "path/to/nimsuggest")
 
 ;; Currently nimsuggest doesn't support nimscript files, so only nim-mode...
 (add-hook 'nim-mode-hook 'nimsuggest-mode)
@@ -72,7 +72,7 @@ your Emacs configuration file (e.g, ~/.emacs.d/init.el):
 ;; (add-hook 'prog-mode-hook 'company-mode)
 ```
 
-Note that above `nim-nimsuggest-path` variable is automatically set
+Note that above `nimsuggest-path` variable is automatically set
 the result of `(executable-find "nimsuggest")`, so if you can get
 value from the `executable-find`, you may not need that
 configuration unless you want to set specific version of nimsuggest.

--- a/flycheck-nimsuggest.el
+++ b/flycheck-nimsuggest.el
@@ -33,8 +33,8 @@
 (require 'flycheck)
 (require 'cl-lib)
 
-(autoload 'nim-call-epc "nim-suggest")
-(autoload 'nim-suggest-available-p "nim-suggest")
+(autoload 'nimsuggest--call-epc "nim-suggest")
+(autoload 'nimsuggest-available-p "nim-suggest")
 
 (defvar flycheck-nimsuggest-error-parser 'flycheck-nimsuggest-error-parser
   "Error parser that parse nimsuggest's erorrs.
@@ -65,7 +65,7 @@ CALLBACK is the status callback passed by Flycheck."
   ;; A callback function, which shall be used to report the results of a
   ;; syntax check back to Flycheck.
   (let ((buffer (current-buffer)))
-    (nim-call-epc
+    (nimsuggest--call-epc
      'chk
      (lambda (errors)
        (condition-case err
@@ -108,7 +108,7 @@ See URL `https://github.com/nim-lang/nimsuggest'."
        :modes '(nim-mode nimscript-mode)
        :predicate (lambda () (and
                          (bound-and-true-p nim-use-flycheck-nimsuggest)
-                         (nim-suggest-available-p))))
+                         (nimsuggest-available-p))))
 
      (add-to-list 'flycheck-checkers 'nim-nimsuggest)))
 

--- a/flycheck-nimsuggest.el
+++ b/flycheck-nimsuggest.el
@@ -28,10 +28,19 @@
 ;; from Emacs 26, this package might be moved to other repository on the future.
 ;; (for less dependencies)
 
+;; Manual setup:
+;;     ;; write below configuration in your init file.
+;;     (add-hook 'nimsuggest-mode-hook 'flycheck-nimsuggest-setup)
+
+;; TODO: move this package to MELPA
+
 ;;; Code:
 
 (require 'flycheck)
 (require 'cl-lib)
+
+;;;###autoload
+(add-hook 'nimsuggest-mode-hook 'flycheck-nimsuggest-setup)
 
 (defvar nim-use-flycheck-nimsuggest t
   "Set nil if you really don’t want to use flycheck-nimsuggest.
@@ -93,11 +102,12 @@ CHECKER and BUFFER are passed to flycheck's function."
                     line column level msg
                     :checker checker :buffer buffer :filename file)))
 
-
 ;;;###autoload
 (defun flycheck-nimsuggest-setup ()
   "Setup flycheck configuration for nimsuggest."
   (when (and (bound-and-true-p nim-use-flycheck-nimsuggest)
+             (not (bound-and-true-p flymake-mode))
+             (funcall 'nimsuggest-available-p)
              (not flycheck-checker))
     (flycheck-select-checker 'nim-nimsuggest)))
 

--- a/flycheck-nimsuggest.el
+++ b/flycheck-nimsuggest.el
@@ -33,6 +33,10 @@
 (require 'flycheck)
 (require 'cl-lib)
 
+(defvar nim-use-flycheck-nimsuggest t
+  "Set nil if you really don’t want to use flycheck-nimsuggest.
+Mainly this variable is debug purpose.")
+
 (autoload 'nimsuggest--call-epc "nim-suggest")
 (autoload 'nimsuggest-available-p "nim-suggest")
 

--- a/nim-capf.el
+++ b/nim-capf.el
@@ -67,18 +67,18 @@
 
 (defun nim-capf--format-candidate (cand)
   "Put text property to CAND."
-  (let ((qpath (nim-epc-qualifiedPath cand)))
+  (let ((qpath (nimsuggest--epc-qualifiedPath cand)))
     (propertize
      (car (last qpath))
-     :nim-line   (nim-epc-line     cand)
-     :nim-column (nim-epc-column   cand)
-     :nim-type   (nim-epc-forth    cand)
-     :nim-doc    (nim-epc-doc      cand)
+     :nim-line   (nimsuggest--epc-line     cand)
+     :nim-column (nimsuggest--epc-column   cand)
+     :nim-type   (nimsuggest--epc-forth    cand)
+     :nim-doc    (nimsuggest--epc-doc      cand)
      :nim-qpath  qpath
-     :nim-file   (nim-epc-filePath cand)
-     :nim-sk     (nim-epc-symkind  cand)
+     :nim-file   (nimsuggest--epc-filePath cand)
+     :nim-sk     (nimsuggest--epc-symkind  cand)
      :nim-sig    (assoc-default
-                  (nim-epc-symkind cand) nim-capf--type-abbrevs))))
+                  (nimsuggest--epc-symkind cand) nim-capf--type-abbrevs))))
 
 (defun nim-capf--format-candidates (_arg candidates)
   "Put text attributes to CANDIDATES."
@@ -90,7 +90,7 @@
 The PREFIX is passed to the CALLBACK."
   ;; currently only support nim-mode (not nimscript-mode)
   (when (derived-mode-p 'nim-mode)
-    (nim-call-epc
+    (nimsuggest--call-epc
      'sug
      (lambda (x) (funcall callback (nim-capf--format-candidates prefix x))))))
 

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -20,18 +20,15 @@
 
 ;;; Commentary:
 
-;; Eldoc supports for Nim.  This package automatically turns on
-;; if you set ‘nimsuggest-path’ and the nimsuggest is working.
+;; Eldoc supports for Nim.  This package automatically turns on.
 
 ;;; Code:
 
 (require 'nim-vars)
-(require 'nim-suggest)
 (require 'nim-helper)
 (require 'cl-lib)
 (require 'eldoc)
 
-(defvar nim-eldoc--data nil)
 (defvar nim-eldoc--skip-regex
   (rx (or (group symbol-start
                  (or "if" "when" "elif" "while"
@@ -40,25 +37,21 @@
                  symbol-end (0+ " "))
           (group line-start (0+ " ")))))
 
+(defun nim-eldoc-p()
+  "Return non-nil if `eldoc-mode' or `global-eldoc-mode' were non-nil."
+  (or (bound-and-true-p eldoc-mode)
+      ;; This mode was added at Emacs 25
+      (bound-and-true-p global-eldoc-mode)))
+
 ;;;###autoload
 (defun nim-eldoc-function ()
   "Return a doc string appropriate for the current context, or nil."
   (interactive)
-  (when (and (or (bound-and-true-p eldoc-mode)
-                 ;; This mode was added at Emacs 25
-                 (bound-and-true-p global-eldoc-mode))
+  (when (and (nim-eldoc-p)
              (not (eq ?\s (char-after (point)))))
     (if (nim-inside-pragma-p)
         (nim-eldoc--pragma-at-point)
-      (nim-eldoc--nimsuggest))))
-
-(defun nim-eldoc--nimsuggest ()
-  (when (nimsuggest-available-p)
-    (unless (nim-eldoc-same-try-p)
-      (nim-eldoc--call-nimsuggest))
-    (when (eq (line-number-at-pos)
-              (assoc-default :line nim-eldoc--data))
-      (assoc-default :str nim-eldoc--data))))
+      (funcall 'nimsuggest-eldoc--nimsuggest))))
 
 ;;;###autoload
 (defun nim-eldoc-on ()
@@ -74,9 +67,7 @@ Major-mode configuration according to the document."
 
 ;;;###autoload
 (defun nim-eldoc-setup ()
-  (if (and nimsuggest-mode (nimsuggest-available-p))
-      (nim-eldoc-on)
-    (nim-eldoc-off)))
+  (if (nim-eldoc-p) (nim-eldoc-on) (nim-eldoc-off)))
 
 (defun nim-eldoc--get-pragma (pragma)
   "Get the PRAGMA's doc string."
@@ -93,71 +84,11 @@ Major-mode configuration according to the document."
     (when (and desc (string< "" desc))
       (format "%s: %s" thing (nim-eldoc--get-pragma thing)))))
 
-(defun nim-eldoc--call-nimsuggest ()
-  (save-excursion
-    (nim-eldoc--move)
-    (nimsuggest--call-epc
-     ;; version 2 protocol can use: ideDef, ideUse, ideDus
-     'dus 'nim-eldoc--update)))
-
-(defun nim-eldoc--move ()
-  (let ((pos  (point))
-        (ppss (syntax-ppss)))
-    (when (nim-eldoc-inside-paren-p)
-      (goto-char (nth 1 ppss))
-      (when (looking-back nim-eldoc--skip-regex nil)
-        (goto-char pos)))))
-
 (defun nim-eldoc-inside-paren-p ()
   (save-excursion
     (let ((ppss (syntax-ppss)))
       (and (< 0 (nth 0 ppss))
            (eq ?\( (char-after (nth 1 ppss)))))))
-
-(defun nim-eldoc-same-try-p ()
-  (or (and (equal (nim-current-symbol)
-                  (assoc-default :name nim-eldoc--data))
-           (eq (assoc-default :line nim-eldoc--data)
-               (line-number-at-pos)))
-      (and (nim-eldoc-inside-paren-p)
-           (save-excursion
-             (nim-eldoc--move)
-             (or
-              ;; for template
-              (eq (point) (assoc-default :pos nim-eldoc--data))
-              ;; for proc
-              (eq (1- (point)) (assoc-default :pos nim-eldoc--data)))))))
-
-(defun nim-eldoc--update (defs)
-  (if defs
-      (nim-eldoc--update-1 defs)
-    (save-excursion
-      (when (nim-eldoc-inside-paren-p)
-        (nim-eldoc--move)
-        (backward-char)
-        (nimsuggest--call-epc 'dus 'nim-eldoc--update-1)))))
-
-(defun nim-eldoc--update-1 (defs)
-  (when defs
-    (setq nim-eldoc--data
-          (list
-           (cons :str  (nim-eldoc-format-string defs))
-           (cons :line (line-number-at-pos))
-           (cons :name (nim-current-symbol))
-           (cons :pos  (point))))
-    (setq eldoc-last-message (assoc-default :str nim-eldoc--data))
-    (message eldoc-last-message)))
-
-(defun nim-eldoc-format-string (defs)
-  "Format data inside DEFS for eldoc.
-DEFS is group of definitions from nimsuggest."
-  ;; TODO: switch if there are multiple defs
-  (let* ((data    (cl-first defs))
-         (forth   (nimsuggest--epc-forth         data))
-         (symKind (nimsuggest--epc-symkind       data))
-         (qpath   (nimsuggest--epc-qualifiedPath data))
-         (doc     (nimsuggest--epc-doc           data)))
-    (nimsuggest--format forth symKind qpath doc)))
 
 ;; backward compatibility
 (defalias 'nim-eldoc-setup 'ignore)

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -50,11 +50,33 @@
              (not (eq ?\s (char-after (point)))))
     (if (nim-inside-pragma-p)
         (nim-eldoc--pragma-at-point)
-      (unless (nim-eldoc-same-try-p)
-        (nim-eldoc--call-nimsuggest))
-      (when (eq (line-number-at-pos)
-                (assoc-default :line nim-eldoc--data))
-        (assoc-default :str nim-eldoc--data)))))
+      (nim-eldoc--nimsuggest))))
+
+(defun nim-eldoc--nimsuggest ()
+  (when (nimsuggest-available-p)
+    (unless (nim-eldoc-same-try-p)
+      (nim-eldoc--call-nimsuggest))
+    (when (eq (line-number-at-pos)
+              (assoc-default :line nim-eldoc--data))
+      (assoc-default :str nim-eldoc--data))))
+
+;;;###autoload
+(defun nim-eldoc-on ()
+  "This may or may not work.  Maybe this configuration has to set on.
+Major-mode configuration according to the document."
+  (interactive)
+  (add-function :before-until (local 'eldoc-documentation-function)
+                'nim-eldoc-function))
+
+(defun nim-eldoc-off ()
+  (interactive)
+  (remove-function (local 'eldoc-documentation-function) 'nim-eldoc-function))
+
+;;;###autoload
+(defun nim-eldoc-setup ()
+  (if (and nimsuggest-mode (nimsuggest-available-p))
+      (nim-eldoc-on)
+    (nim-eldoc-off)))
 
 (defun nim-eldoc--get-pragma (pragma)
   "Get the PRAGMA's doc string."

--- a/nim-eldoc.el
+++ b/nim-eldoc.el
@@ -21,7 +21,7 @@
 ;;; Commentary:
 
 ;; Eldoc supports for Nim.  This package automatically turns on
-;; if you set ‘nim-nimsuggest-path’ and the nimsuggest is working.
+;; if you set ‘nimsuggest-path’ and the nimsuggest is working.
 
 ;;; Code:
 
@@ -74,7 +74,7 @@
 (defun nim-eldoc--call-nimsuggest ()
   (save-excursion
     (nim-eldoc--move)
-    (nim-call-epc
+    (nimsuggest--call-epc
      ;; version 2 protocol can use: ideDef, ideUse, ideDus
      'dus 'nim-eldoc--update)))
 
@@ -113,7 +113,7 @@
       (when (nim-eldoc-inside-paren-p)
         (nim-eldoc--move)
         (backward-char)
-        (nim-call-epc 'dus 'nim-eldoc--update-1)))))
+        (nimsuggest--call-epc 'dus 'nim-eldoc--update-1)))))
 
 (defun nim-eldoc--update-1 (defs)
   (when defs
@@ -131,10 +131,10 @@
 DEFS is group of definitions from nimsuggest."
   ;; TODO: switch if there are multiple defs
   (let* ((data    (cl-first defs))
-         (forth   (nim-epc-forth         data))
-         (symKind (nim-epc-symkind       data))
-         (qpath   (nim-epc-qualifiedPath data))
-         (doc     (nim-epc-doc           data)))
+         (forth   (nimsuggest--epc-forth         data))
+         (symKind (nimsuggest--epc-symkind       data))
+         (qpath   (nimsuggest--epc-qualifiedPath data))
+         (doc     (nimsuggest--epc-doc           data)))
     (nimsuggest--format forth symKind qpath doc)))
 
 ;; backward compatibility

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -83,7 +83,7 @@
 
 ;; ```el
 ;; ;; can be optional.  See below note
-;; (setq nim-nimsuggest-path "path/to/nimsuggest")
+;; (setq nimsuggest-path "path/to/nimsuggest")
 
 ;; ;; Currently nimsuggest doesn't support nimscript files, so only nim-mode...
 ;; (add-hook 'nim-mode-hook 'nimsuggest-mode)
@@ -96,7 +96,7 @@
 ;; ;; (add-hook 'prog-mode-hook 'company-mode)
 ;; ```
 
-;; Note that above `nim-nimsuggest-path` variable is automatically set
+;; Note that above `nimsuggest-path` variable is automatically set
 ;; the result of `(executable-find "nimsuggest")`, so if you can get
 ;; value from the `executable-find`, you may not need that
 ;; configuration unless you want to set specific version of nimsuggest.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -151,6 +151,13 @@
   (setq-local commenter-config nim-comment)
   (commenter-setup)
 
+  ;; ElDoc
+  ;; See `eldoc-documentation-function'. Don't move this function out
+  ;; side of major-mode function; it may cause weird eldoc behavior
+  ;; (`eldoc-documentation-function' was set, but eldoc doesn't start
+  ;; only first time you open a nim file)
+  (nim-eldoc-on)
+
   ;; SMIE
   (smie-setup nim-mode-smie-grammar 'nim-mode-smie-rules
               :forward-token 'nim-mode-forward-token

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -120,6 +120,7 @@
 (require 'paren) ; for ‘show-paren-data-function’
 (require 'nim-fill)
 (require 'commenter)
+(require 'nim-eldoc) ; for pragma info
 
 (put 'nim-mode 'font-lock-defaults '(nim-font-lock-keywords nil t))
 

--- a/nim-rx.el
+++ b/nim-rx.el
@@ -23,8 +23,8 @@
 (require 'cl-lib)
 (require 'nim-vars)
 
-(eval-and-compile
-  (defvar nim-rx-constituents
+(defvar nim-rx-constituents
+  (eval-when-compile
     (let* ((constituents1
             (cl-loop for (sym . kwd) in `((dedenter          . ("elif" "else" "of" "except" "finally"))
                                           (defun             . ("proc" "method" "converter" "iterator" "template" "macro"))
@@ -89,8 +89,10 @@
                                                         (concat (char-to-string (1+ ?\')) "-" (char-to-string 126))))))
                                  (group "'"))))))
       (append constituents1 constituents2))
-    "Additional Nim specific sexps for `nim-rx'.")
+    ) ; end of eval-when-compile
+  "Additional Nim specific sexps for `nim-rx'.")
 
+(eval-and-compile
   (defmacro nim-rx (&rest regexps)
     "Nim mode specialized rx macro.
 This variant of `rx' supports common nim named REGEXPS."

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -561,7 +561,7 @@ This uses `xref-find-definitions' as backend."
   (define-key nimsuggest-mode-map (kbd "M-.") #'nimsuggest-find-definition)
   (define-key nimsuggest-mode-map (kbd "M-,") #'pop-tag-mark)
   (require 'etags)
-  (defun nimsuggest-find-definition (id)
+  (defun nimsuggest-find-definition ()
     "Go to the definition of the symbol currently under the cursor."
     (nimsuggest--call-epc
      'def

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -2,8 +2,6 @@
 
 ;;; Commentary:
 
-;; TODO: implement xref find reference function
-
 ;; memo
 ;; https://irclogs.nim-lang.org/12-07-2017.html
 
@@ -392,7 +390,8 @@ crash when some emacsclients open the same file."
       (nimsuggest--show-doc))))
 
 
-;;; Flymake
+;;; Flymake integration from Emacs 26
+
 (defun nimsuggest--flymake-error-parser (errors buffer)
   "Return list of result of `flymake-make-diagnostic' from ERRORS.
 The list can be nil.  ERRORS will be skipped if BUFFER and

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -125,14 +125,6 @@ The CALLBACK is called with a list of ‘nimsuggest--epc’ structs."
           (lambda (err)
             (message "%s" (error-message-string err))))))))
 
-(defvar nim-dirty-directory
-  ;; Even users changed the temp directory name,
-  ;; ‘file-name-as-directory’ ensures suffix directory separator.
-  (mapconcat 'file-name-as-directory
-             `(,temporary-file-directory "emacs-nim-mode") "")
-  "Directory name, which nimsuggest uses temporarily.
-Note that this directory is removed when you exit from Emacs.")
-
 (defun nimsuggest--get-dirty-dir ()
   "Return temp directory.
 The directory name consists of `nimsuggest-dirty-directory' and current
@@ -320,14 +312,6 @@ crash when some emacsclients open the same file."
 ;;; misc
 
 ;; work in progress
-
-(defvar nimsuggest-doc-mode-map
-  (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map (make-composed-keymap special-mode-map))
-    (define-key map (kbd ">") 'nimsuggest-doc-next)
-    (define-key map (kbd "<") 'nimsuggest-doc-previous)
-    map)
-  "Nimsuggest doc mode keymap.")
 
 (defcustom nimsuggest-doc-directive
   'def

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -381,12 +381,13 @@ character address of the specified TYPE."
                    (1+  ppss9-last))))))))
 
 (defvar nim--pragma-regex
-  (let ((pragma (cl-loop for (kwd . _) in nim-pragmas collect kwd)))
-    (apply
-     `((lambda ()
-         (nim-rx (or (group (or (group (? ".") "}")
-                                (group "." (eval (cons 'or (list ,@pragma))))))
-                     (group (regexp ,(nim--format-keywords pragma))))))))))
+  (eval-when-compile
+    (let ((pragma (cl-loop for (kwd . _) in nim-pragmas collect kwd)))
+      (apply
+       `((lambda ()
+           (nim-rx (or (group (or (group (? ".") "}")
+                                  (group "." (eval (cons 'or (list ,@pragma))))))
+                       (group (regexp ,(nim--format-keywords pragma)))))))))))
 
 (defun nim-pragma-matcher (&optional _start-pos)
   "Highlight pragma."

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -28,7 +28,8 @@
 ;; `revert-buffer', but I'm not sure this is good approach...
 
 ;;; Code:
-(eval-and-compile (require 'nim-rx))
+(require 'nim-vars)
+(require 'nim-rx)
 
 (defvar nim-font-lock-keywords
   `((,(nim-rx (1+ "\t")) . 'nim-tab-face)

--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -327,7 +327,6 @@ character address of the specified TYPE."
   (when (nth 3 (save-excursion (syntax-ppss)))
     (re-search-forward "\\s|" nil t)))
 
-(defconst nim--backticks-regex (nim-rx backticks))
 (defun nim-backtick-matcher (&optional _start-pos)
   "Highlight matcher for ``symbol`` in comment."
   (nim-matcher-func
@@ -335,7 +334,7 @@ character address of the specified TYPE."
      (unless (nth 4 (save-excursion (syntax-ppss)))
        (re-search-forward "\\s<" nil t)))
    (lambda ()
-     (not (re-search-forward nim--backticks-regex nil t)))
+     (not (re-search-forward (nim-rx backticks) nil t)))
    (lambda (ppss) (not (nth 4 ppss)))))
 
 (defconst nim--string-interpolation-regex
@@ -423,27 +422,24 @@ character address of the specified TYPE."
        nil)
       (t t)))))
 
-(defconst nim--colon-type-regex (nim-rx colon-type))
 (defun nim-type-matcher (&optional _start-pos)
   (nim-matcher-func
    'nim-skip-comment-and-string
-   (lambda () (not (re-search-forward nim--colon-type-regex nil t)))
+   (lambda () (not (re-search-forward (nim-rx colon-type) nil t)))
    (lambda (ppss)
      (or (eq (nth 0 ppss) 0)
          (not (eq ?\( (char-after (nth 1 ppss))))))))
 
-(defconst nim--colon-numbers-regex (nim-rx nim-numbers))
 (defun nim-number-matcher (&optional _start-pos)
   (nim-matcher-func
    'nim-skip-comment-and-string
-   (lambda () (not (re-search-forward nim--colon-numbers-regex nil t)))
+   (lambda () (not (re-search-forward (nim-rx nim-numbers) nil t)))
    (lambda (ppss) (or (nth 3 ppss) (nth 4 ppss)))))
 
-(defconst nim--font-lock-defun-regex (nim-rx font-lock-defun))
 (defun nim-proc-matcher (&optional _start-pos)
   (nim-matcher-func
    'nim-skip-comment-and-string
-   (lambda () (not (re-search-forward nim--font-lock-defun-regex nil t)))
+   (lambda () (not (re-search-forward (nim-rx font-lock-defun) nil t)))
    (lambda (ppss) (or (nth 3 ppss) (nth 4 ppss)))))
 
 (defun nim-syntax-disable-maybe ()
@@ -459,4 +455,3 @@ will be used if only user didn't set ‘font-lock-maximum-decoration’."
 
 (provide 'nim-syntax)
 ;;; nim-syntax.el ends here
-

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -143,11 +143,13 @@ You don't need to set this if the nim executable is inside your PATH."
   :type '(repeat string)
   :group 'nim)
 
-(defcustom nim-nimsuggest-path (executable-find "nimsuggest")
+(defcustom nimsuggest-path (executable-find "nimsuggest")
   "Path to the nimsuggest binary."
   :type '(choice (const :tag "Path of nimsuggest binary" string)
                  (const :tag "" nil))
   :group 'nim)
+;; Added Oct 17, 2017
+(define-obsolete-variable-alias 'nim-nimsuggest-path 'nimsuggest-path)
 
 (defcustom nim-suggest-options '("--v2")
   "Options for Nimsuggest.
@@ -156,6 +158,18 @@ epc function."
   :type '(choice (repeat :tag "List of options" string)
                  (const :tag "" nil))
   :group 'nim)
+
+(defcustom nimsuggest-dirty-directory
+  ;; Even users changed the temp directory name,
+  ;; ‘file-name-as-directory’ ensures suffix directory separator.
+  (mapconcat 'file-name-as-directory
+             `(,temporary-file-directory "emacs-nim-mode") "")
+  "Directory name, which nimsuggest uses temporarily.
+Note that this directory is removed when you exit from Emacs."
+  :type 'directory
+  :group 'nim)
+;; Added Oct 17, 2017
+(define-obsolete-variable-alias 'nim-dirty-directory 'nimsuggest-dirty-directory)
 
 (defvar nim-suggest-local-options '()
   "Options for Nimsuggest.

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -180,6 +180,7 @@ specific directory or buffer.  See also ‘dir-locals-file’.")
   (rx (or "\\" "/") (in "nN") "im" (or "\\" "/") "compiler" (or "\\" "/")))
 (defvar nim-inside-compiler-dir-p nil)
 
+;; Keymaps
 (defvar nim-mode-map
   (let ((map (make-sparse-keymap)))
     ;; Allowed keys: C-c with control-letter, or {,}, <, >, :, ;
@@ -192,6 +193,14 @@ specific directory or buffer.  See also ‘dir-locals-file’.")
     ;; implement mark-defun
     ;;
     map))
+
+(defvar nimsuggest-doc-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map (make-composed-keymap special-mode-map))
+    (define-key map (kbd ">") 'nimsuggest-doc-next)
+    (define-key map (kbd "<") 'nimsuggest-doc-previous)
+    map)
+  "Nimsuggest doc mode keymap.")
 
 ;; Turn off syntax highlight for big files
 ;; FIXME: what number should we set as default?

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -616,10 +616,6 @@ which supports ‘chk’ option for EPC.")
 (make-obsolete-variable
  'nimsuggest-vervosity 'nimsuggest-check-vervosity "0.1.0")
 
-;; flycheck-nimsuggest
-(defvar nim-use-flycheck-nimsuggest t
-  "Set nil if you really don’t want to use flycheck-nimsuggest.
-Mainly this variable is debug purpose.")
 
 (provide 'nim-vars)
 ;;; nim-vars.el ends here

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -23,15 +23,6 @@
   :link '(url-link "http://nim-lang.org/")
   :group 'languages)
 
-(defface nim-tab-face
-  '((((class color) (background dark))
-     (:background "grey22" :foreground "darkgray"))
-    (((class color) (background light))
-     (:background "beige"  :foreground "lightgray"))
-    (t (:inverse-video t)))
-  "Face used to visualize TAB."
-  :group 'nim)
-
 (defface nim-font-lock-export-face
   '((t :weight bold
        :slant italic
@@ -148,8 +139,6 @@ You don't need to set this if the nim executable is inside your PATH."
   :type '(choice (const :tag "Path of nimsuggest binary" string)
                  (const :tag "" nil))
   :group 'nim)
-;; Added Oct 17, 2017
-(define-obsolete-variable-alias 'nim-nimsuggest-path 'nimsuggest-path)
 
 (defcustom nim-suggest-options '("--v2")
   "Options for Nimsuggest.
@@ -168,8 +157,6 @@ epc function."
 Note that this directory is removed when you exit from Emacs."
   :type 'directory
   :group 'nim)
-;; Added Oct 17, 2017
-(define-obsolete-variable-alias 'nim-dirty-directory 'nimsuggest-dirty-directory)
 
 (defvar nim-suggest-local-options '()
   "Options for Nimsuggest.
@@ -607,6 +594,7 @@ The description is unofficial; PRs are welcome.")
   '(; from unittest.nim
     "NIMTEST_OUTPUT_LVL" "NIMTEST_NO_COLOR" "NIMTEST_ABORT_ON_ERROR"))
 
+
 ;; obsolete
 (defvar nimsuggest-vervosity "--verbosity:0"
   "This variable will not be needed for latest nimsuggest.
@@ -616,6 +604,14 @@ which supports ‘chk’ option for EPC.")
 (make-obsolete-variable
  'nimsuggest-vervosity 'nimsuggest-check-vervosity "0.1.0")
 
+(make-obsolete
+ 'nim-tab-face
+ "The nim-tab-face was obsoleted, use `white-space-mode' instead to highlight tabs."
+ "Oct/20/2017")
+
+;; Added Oct 17, 2017
+(define-obsolete-variable-alias 'nim-nimsuggest-path 'nimsuggest-path "Oct/20/2017")
+(define-obsolete-variable-alias 'nim-dirty-directory 'nimsuggest-dirty-directory "Oct/20/2017")
 
 (provide 'nim-vars)
 ;;; nim-vars.el ends here

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -167,6 +167,7 @@ specific directory or buffer.  See also ‘dir-locals-file’.")
   (rx (or "\\" "/") (in "nN") "im" (or "\\" "/") "compiler" (or "\\" "/")))
 (defvar nim-inside-compiler-dir-p nil)
 
+
 ;; Keymaps
 (defvar nim-mode-map
   (let ((map (make-sparse-keymap)))
@@ -189,6 +190,7 @@ specific directory or buffer.  See also ‘dir-locals-file’.")
     map)
   "Nimsuggest doc mode keymap.")
 
+;;; Syntax table
 ;; Turn off syntax highlight for big files
 ;; FIXME: what number should we set as default?
 (defcustom nim-syntax-disable-limit 400000

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -190,6 +190,14 @@ specific directory or buffer.  See also ‘dir-locals-file’.")
     map)
   "Nimsuggest doc mode keymap.")
 
+;; xref supported key binds:
+;;   esc-map "." xref-find-definitions
+;;   esc-map "," xref-pop-marker-stack
+;;   esc-map "?" xref-find-references
+;;   ctl-x-4-map "." xref-find-definitions-other-window
+;;   ctl-x-5-map "." xref-find-definitions-other-frame
+;;   TODO: esc-map [?\C-.] xref-find-apropos
+
 ;;; Syntax table
 ;; Turn off syntax highlight for big files
 ;; FIXME: what number should we set as default?


### PR DESCRIPTION
- added xref's find definitions and references commands (xref introduced from Emacs 25.1)
- some variables and functions were renamed with nimsuggest prefix
- obsolete nim-tab-face because whitespace-mode does much better job and user configurable