### PR TITLE
Append space to comment start

### DIFF
--- a/nim-vars.el
+++ b/nim-vars.el
@@ -275,7 +275,7 @@ It makes underscores and dots word constituent chars.")
 
 (defconst nim-comment
   `((single
-     . ((comment-start      . "#")
+     . ((comment-start      . "# ")
         (comment-end        . "")
         (comment-start-skip . ,(rx "#" (? "#") (? " ")))
         (comment-use-syntax . t)))


### PR DESCRIPTION
It saves keystrokes, and also it is a good style to havethat space after comment anyway