### PR TITLE
Make completion-at-point-functions as local hook

### DIFF
--- a/nim-capf.el
+++ b/nim-capf.el
@@ -314,13 +314,15 @@ List of WORDS are used as completion candidates."
 
     ;; Add builtin capf function (pragma and some keywords)
     (unless (memq capf completion-at-point-functions)
-      (add-hook 'completion-at-point-functions capf))
+      (add-hook 'completion-at-point-functions
+                capf nil 'local))
 
     ;; if company-mode is disabled, just add nimsuggest's capf function.
     (unless (or (bound-and-true-p company-mode)
                 (bound-and-true-p global-company-mode))
       (unless (memq 'nim-capf-nimsuggest-completion-at-point completion-at-point-functions)
-        (add-hook 'completion-at-point-functions 'nim-capf-nimsuggest-completion-at-point)))
+        (add-hook 'completion-at-point-functions
+                  'nim-capf-nimsuggest-completion-at-point nil 'local)))
 
     ;; Add an asynchronous backend for company-mode.
     ;; The big difference between `company-nimsuggest' and


### PR DESCRIPTION
Keep global `completion-at-point-functions` hook clean, as it is generic hook used by many modes.

Other modes like `lisp-interaction-mode` and `python-mode` seem to keep this convention as well.

Just noticed that this is part of major mode conventions:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Major-Mode-Conventions.html#Major-Mode-Conventions