### PR TITLE
add "func" as a keyword for a {.noSideEffects.} proc

### DIFF
--- a/nim-rx.el
+++ b/nim-rx.el
@@ -27,8 +27,8 @@
   (eval-when-compile
     (let* ((constituents1
             (cl-loop for (sym . kwd) in `((dedenter          . ("elif" "else" "of" "except" "finally"))
-                                          (defun             . ("proc" "method" "converter" "iterator" "template" "macro"))
-                                          (block-start-defun . ("proc" "method" "converter" "iterator"
+                                          (defun             . ("proc" "func" "method" "converter" "iterator" "template" "macro"))
+                                          (block-start-defun . ("proc" "func" "method" "converter" "iterator"
                                                                 "template" "macro"
                                                                 "if" "elif" "else" "when" "while" "for" "case" "of"
                                                                 "try" "except" "finally"

--- a/nim-smie.el
+++ b/nim-smie.el
@@ -36,7 +36,7 @@
 ;; INTERNAL VARIABLES
 (defvar nim-smie--line-info nil)
 (defvar nim-smie--defuns
-  '("proc" "method" "iterator" "template" "macro" "converter"))
+  '("proc" "func" "method" "iterator" "template" "macro" "converter"))
 
 (defconst nim-mode-smie-grammar
   (smie-prec2->grammar
@@ -73,7 +73,7 @@
                          (exp "=" "enum" enum-eq-comma)
                          (exp "=" "tuple" exp-colon)
                          (type-constituent))
-       (func ("proc" func-body) ("method" func-body) ("iterator" func-body)
+       (func ("proc" func-body) ("func" func-body) ("method" func-body) ("iterator" func-body)
              ("template" func-body) ("macro" func-body) ("converter" func-body))
        (func-body (any "=" ";"))
        (inst3

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -65,7 +65,7 @@ Note that this configuration affects other ‘template’, ‘macro’,
   :group 'nim)
 
 (defcustom nim-smie-indent-stoppers
-  '("proc" "template" "macro" "iterator" "converter" "type")
+  '("proc" "func" "template" "macro" "iterator" "converter" "type")
   "Indentation behavior after empty line.
 You can specify list of string, which you want to stop indenting.
 If it’s nil, it does nothing."
@@ -307,7 +307,7 @@ It makes underscores and dots word constituent chars.")
   '("addr" "and" "as" "asm" "atomic" "bind" "block" "break" "case"
     "cast" "concept" "const" "continue" "converter" "defer" "discard" "distinct"
     "div" "do" "elif" "else" "end" "enum" "except" "export" "finally" "for"
-    "from" "generic" "if" "import" "in" "include" "interface" "isnot"
+    "func" "from" "generic" "if" "import" "in" "include" "interface" "isnot"
     "iterator" "lambda" "let" "macro" "method" "mixin" "mod" "nil" "not"
     "notin" "object" "of" "or" "out" "proc" "ptr" "raise" "ref" "return"
     "shared" "shl" "shr" "static" "template" "try" "tuple" "type" "using"


### PR DESCRIPTION
Since the `func` keyword is finally usable on the current devel as a {.noSideEffects.} proc, I thought it'd be a good idea to include it into nim-mode. Otherwise using it is... ugly.

Only just looked into the code for the first time, so I hope I didn't forget to add something somewhere. Seems to work fine for me.