### PR TITLE
No autoload dependency

### DIFF
--- a/nim-capf.el
+++ b/nim-capf.el
@@ -331,7 +331,8 @@ List of WORDS are used as completion candidates."
     (when (bound-and-true-p company-backends)
       (add-to-list 'company-backends 'company-nimsuggest))))
 
-;;;###autoload (add-hook 'nimsuggest-mode-hook 'nim-capf-setup)
+;;;###autoload
+(add-hook 'nimsuggest-mode-hook 'nim-capf-setup)
 
 
 ;; Suggestion-box-el

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -234,8 +234,10 @@ instead.  The default regex’s matching word is [Package]."
                  (nimscript-mode))))))))
 
 ;;; `auto-mode-alist'
-;;;###autoload (add-to-list 'auto-mode-alist '("\\.nim\\'" . nim-mode))
-;;;###autoload (add-to-list 'auto-mode-alist '("\\.nim\\(ble\\|s\\)\\'" . nimscript-mode-maybe))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.nim\\'" . nim-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.nim\\(ble\\|s\\)\\'" . nimscript-mode-maybe))
 
 
 ;;; Font locks

--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -626,7 +626,8 @@ The EPC-RESULT can be result of both def and/or dus."
 (defvar nimsuggest-find-definition-function nil
   "Function for `nimsuggest-find-definition'.")
 
-;;;###autoload (add-hook 'nimsuggest-mode-hook 'nimsuggest-xref-setup)
+;;;###autoload
+(add-hook 'nimsuggest-mode-hook 'nimsuggest-xref-setup)
 ;;;###autoload
 (defun nimsuggest-xref-setup ()
   "Setup xref backend for nimsuggest."


### PR DESCRIPTION
I convert autoload comments to commands.  When I load the library with ``load-library`` the autoload mock isn't generated. These commands are now executed twice, but in general it lowers the entrance barrier to contribute to nim-mode, because the ``autoload`` indirection isn't required anymore to load the library properly.

I do thins, because I think autoload here really gets in the way. Loading a library with ``load-library`` is properly documented. Loading the autoload mock of a library that needs to be generated first is not properly documented. Apart from that ``autoload`` is very confusing in it's name, it does the exact opposite of automatically loading something. With this change cloning nim-mode and loading it with ``(add-to-list 'load-path "/path/to/nim-mode/") (load-library "nim-mode")`` just works. No need to dive in the curiosity of autoload.


