### PR TITLE
add test, remove "" skip, fix #210

### DIFF
--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -210,21 +210,6 @@ is used to limit the scan."
              (when (eq num-quotes 3)
                (nim-pretty-triple-double-quotes
                 quote-starting-pos (+ quote-starting-pos 3))))
-            ((and string-start (< string-start (point))
-                  ;; Skip "" in the raw string literal
-                  (eq ?r (char-before string-start))
-                  (or
-                   ;;  v point is here
-                   ;; ""
-                   (and
-                    (eq ?\" (char-before (1- (point))))
-                    (eq ?\" (char-before (point))))
-                   ;; v point is here
-                   ;; ""
-                   (and
-                    (eq ?\" (char-before (point)))
-                    (eq ?\" (char-after  (point))))))
-             nil)
             ((= num-quotes num-closing-quotes)
              ;; This set of quotes delimit the end of a string.
              ;; If there are some double quotes after quote-ending-pos,

--- a/tests/syntax/string.nim
+++ b/tests/syntax/string.nim
@@ -40,3 +40,5 @@ var unbalancedDoubleQuote4 = """"enclosed double quotes""""
 
 var rawString = r"foo""bar""buzz"
 # this line should be comment face
+var rawString2 = r""
+# this line should be comment face

--- a/tests/test-syntax.el
+++ b/tests/test-syntax.el
@@ -21,7 +21,9 @@
      (expect (face-at-point-of 10 :on "string.nim")
              :to-be font-lock-string-face)
      (expect (face-at-point-of 5  :on "string.nim")
-             :to-be font-lock-variable-name-face))
+             :to-be font-lock-variable-name-face)
+     (expect (face-at-point-of 1251 :on "string.nim")
+             :to-be font-lock-comment-face))
 
  (it "should highlight inside here document"
      (assert-highlight-between 33 86 :on "string.nim"


### PR DESCRIPTION
I would like to point out, that a raw string is not just an `r` before the string literal, it can be any identifier before a string literal.

My fix isn't 100% correct. It treats ``r" abc""def "`` like two different literals, but for syntax highlighting, that doesn't matter at all.