### PR TITLE
Fix extracting the frame number

### DIFF
--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -297,7 +297,7 @@ The CALLBACK function is called when it got the response."
 The directory name consists of `nimsuggest-dirty-directory' and current
 frame number.  The frame number is required to prevent Emacs
 crash when some emacsclients open the same file."
-  (let* ((frame-num (nth 2 (split-string (format "%s" (selected-frame)) " ")))
+  (let* ((frame-num (car (last (split-string (format "%s" (selected-frame)) " "))))
          (frame-num-str (substring frame-num 0 (1- (length frame-num)))))
     (file-name-as-directory (concat nimsuggest-dirty-directory frame-num-str))))
 


### PR DESCRIPTION
The code incorrectly assumed that the frame number is going always to be at the third place in the split string, but the emacs frame title which is included in the string extracted with `(selected-frame)` can actually be customized using the `frame-title-format` var and might include spaces.

On Windows this actually made the extension completely unusable for me, since it erroneously extracted the full file path from my customized frame title which made it impossible to create the necessary temp file (on Windows filenames can't include colons like in `C:\foo.nim`).