### PR TITLE
Preserve doc spaces in eldoc

### DIFF
--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -445,7 +445,7 @@ was outdated."))
 
 (defun nimsuggest--format (forth symKind qpath doc)
   "Highlight returned result from nimsuggest of FORTH, SYMKIND, QPATH, and DOC."
-  (let* ((doc (mapconcat 'identity (split-string doc "\n") ""))
+  (let* ((doc (mapconcat 'identity (split-string doc "\n") " "))
          (name
           (if (eq (length (cdr qpath)) 1)
               (cadr qpath)


### PR DESCRIPTION
Newlines in the doc output are simply getting stripped, which results in docs shown in eldoc looking like this:
`Marks ``socket`` as accepting connections.``Backlog`` specifies the maximum length of thequeue of pending connections.Raises an OSError error upon failure.`

With this change it looks like this:
`Marks ``socket`` as accepting connections. ``Backlog`` specifies the maximum length of the queue of pending connections.  Raises an OSError error upon failure.`