### PR TITLE
font lock changes

### DIFF
--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -42,17 +42,10 @@
      ;; (8 font-lock-type-face keep t) TODO nim-rx needs a proper colon-type expression
      )
 
-    ;; Highlight type words
-    (,(nim-rx ;; (or identifier quoted-chars) (? "*") (* " ")
-       ;; everything behind a colon (:) is interpreted as a type
-       ":" (* " ")
-       (? (and "var " (* " ")))
-       (? (and (* (or "ref " "ptr ")) (* " ")))
-       (group identifier))
+    ;; Highlight everything that starts with a capital letter as type.
+    (,(rx symbol-start (char upper) (* (char alnum "_")) symbol-end) . (0 font-lock-type-face keep))
 
-     (1 font-lock-type-face keep))
-
-    ;; warning face for tab characters.
+    ;; Warning face for tab characters.
     ("	+" . (0 font-lock-warning-face))
 
     ;; This only works if it’s one line

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -331,24 +331,17 @@ It makes underscores and dots word constituent chars.")
     "using" "var" "when" "while" "with" "without" "xor" "yield")
   "Nim keywords.
 The above string is taken from URL
-`https://nim-lang.org/docs/manual.html#lexical-analysis-identifiers-amp-keywords' 
+`https://nim-lang.org/docs/manual.html#lexical-analysis-identifiers-amp-keywords'
 for easy updating.")
 
 (defconst nim-types
   '("int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16" "uint32"
-    "uint64" "float" "float32" "float64" "bool" "char" "string" "cstring"
-    "pointer" "expr" "stmt" "typedesc" "void" "auto" "any"
-    "untyped" "typed" "range" "array" "openArray" "Ordinal" "seq" "set"
-    "TGenericSeq" "PGenericSeq" "NimStringDesc" "NimString" "byte" "Natural"
-    "Positive" "RootObj" "RootRef" "RootEffect" "TimeEffect" "IOEffect"
-    "ReadIOEffect" "WriteIOEffect" "ExecIOEffect"
-    "TResult" "Endianness" "ByteAddress" "BiggestInt" "BiggestFloat"
+    "uint64" "float" "float32" "float64" "bool" "char" "string"
+    "pointer" "typedesc" "void" "auto" "any" "sink" "lent"
+    "untyped" "typed" "range" "array" "openArray" "seq" "set" "byte"
+    ;; c interop types
     "cchar" "cschar" "cshort" "cint" "clong" "clonglong" "cfloat" "cdouble"
-    "clongdouble" "cstringArray" "PFloat32" "PFloat64" "PInt64" "PInt32"
-    "SomeSignedInt" "SomeUnsignedInt" "SomeInteger" "SomeOrdinal" "SomeReal"
-    "SomeNumber" "Slice" "shared" "guarded"
-    "NimNode" "GC_Strategy" "File" "FileHandle" "FileMode"
-    "TaintedString" "PFrame" "TFrame")
+    "cstring" "clongdouble" "cstringArray")
   "Nim types defined in <lib/system.nim>.")
 
 (defconst nim-exceptions

--- a/nim-vars.el
+++ b/nim-vars.el
@@ -338,7 +338,7 @@ for easy updating.")
   '("int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16" "uint32"
     "uint64" "float" "float32" "float64" "bool" "char" "string"
     "pointer" "typedesc" "void" "auto" "any" "sink" "lent"
-    "untyped" "typed" "range" "array" "openArray" "seq" "set" "byte"
+    "untyped" "typed" "range" "array" "openArray" "varargs" "seq" "set" "byte"
     ;; c interop types
     "cchar" "cschar" "cshort" "cint" "clong" "clonglong" "cfloat" "cdouble"
     "cstring" "clongdouble" "cstringArray")


### PR DESCRIPTION
Initially I thought to highlight everything past a colon as a type. This worked great for my style of programming but in the Nim repository it is far too often normal code after a colon. The new heuristic is, everything starting with a capital letter is a type. Makes constants such as ``Pi`` highlighted as types as well.