### PR TITLE
Support alist form of font-lock-maximum-decoration

### DIFF
--- a/nim-mode.el
+++ b/nim-mode.el
@@ -248,8 +248,7 @@ instead.  The default regex’s matching word is [Package]."
             (cl-typecase (or arg font-lock-maximum-decoration)
               (null (nim--get-font-lock-keywords 0))
               (list
-               (nim--set-font-lock-keywords
-                'nim-mode
+               (nim--get-font-lock-keywords
                 (or (assoc-default 'nim-mode font-lock-maximum-decoration)
                     (assoc-default t font-lock-maximum-decoration)
                     t)))


### PR DESCRIPTION
`nim--set-font-lock-keywords` was (incorrectly) called recursively, iff `font-lock-maximum-decoration` is an alist.

This patch changes the call to `nim--set-font-lock-keywords` to `nim--get-font-lock-keywords` which seems to be correct.

This fixes #228.