### PR TITLE
Fix nil buffer-file-name in doc config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can copy and adjust the following configuration into your local
 
   ;; Make files in the nimble folder read only by default.
   ;; This can prevent to edit them by accident.
-  (when (string-match "/\.nimble/" buffer-file-name) (read-only-mode 1))
+  (when (string-match "/\.nimble/" (or (buffer-file-name) "")) (read-only-mode 1))
 
   ;; If you want to experiment, you can enable the following modes by
   ;; uncommenting their line.


### PR DESCRIPTION
In README.md there is a configuration code example:

```
  ;; Make files in the nimble folder read only by default.
  ;; This can prevent to edit them by accident.
  (when (string-match "/\.nimble/" buffer-file-name) (read-only-mode 1))

```
However this line is problematic when buffer-file-name returns nil. 

In peculiar if you try to html-export (C-c C-e h o) this org-mode file: 

```
#+begin_src nim
echo "Hello"
#+end_src

#+RESULTS:
: Hello
```

you get this error:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  string-match("/.nimble/" nil)
  (if (string-match "/.nimble/" buffer-file-name) (progn (read-only-mode 1)))
  (when (string-match "/.nimble/" buffer-file-name) (read-only-mode 1))

```

This PR fixes this by replacing:

` (when (string-match "/\.nimble/" buffer-file-name) (read-only-mode 1))
`

by

` (when (string-match "/\.nimble/" (or (buffer-file-name) "")) (read-only-mode 1))
`

that handles the case where the buffer is not associated to a file.