### PR TITLE
Prevent double call to shell-quote-argument.

### DIFF
--- a/nim-compile.el
+++ b/nim-compile.el
@@ -97,7 +97,7 @@ The config file would one of those: config.nims, PROJECT.nim.cfg, or nim.cfg."
       nim-compile--current-command
     (setq nim-compile--current-command
           (let ((file (when buffer-file-name
-                        (shell-quote-argument buffer-file-name))))
+                        buffer-file-name)))
             (when file
               (cond
                ;; WIP


### PR DESCRIPTION
Fixes  nim-lang/nim-mode#240.  

Since `nim-compile--get-compile-command` is calling `nim--fmt` which applies `shell-quote-argument` to the compile command, arguments and file name there is no need to quote `buffer-file-name`.