### PR TITLE
org-element-at-point cannot be used in non-Org buffer

### DIFF
--- a/nim-mode.el
+++ b/nim-mode.el
@@ -164,9 +164,12 @@
             #'nim-indent-post-self-insert-function 'append 'local)
   (add-hook 'which-func-functions #'nim-info-current-defun nil t)
 
-  ;; Workaround with org
-  (when (and (eq major-mode 'org-mode) (fboundp 'org-in-src-block-p) (org-in-src-block-p))
-    (modify-syntax-entry ?# "<" nim-mode-syntax-table))
+  ;; Workaround with org comments in order to properly
+  ;; detect opening #[ and closing comments ]#
+  (when (and (derived-mode-p 'org-mode)
+              (fboundp 'org-in-src-block-p) (org-in-src-block-p))
+    (modify-syntax-entry ?# ". 124b" nim-mode-syntax-table)
+    (modify-syntax-entry ?[ ". 23" nim-mode-syntax-table))
 
   ;; Because indentation is not redundant, we cannot safely reindent code.
   (setq-local electric-indent-inhibit t)

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -165,7 +165,7 @@
   (add-hook 'which-func-functions #'nim-info-current-defun nil t)
 
   ;; Workaround with org
-  (when (and (fboundp 'org-in-src-block-p) (org-in-src-block-p))
+  (when (and (eq major-mode 'org-mode) (fboundp 'org-in-src-block-p) (org-in-src-block-p))
     (modify-syntax-entry ?# "<" nim-mode-syntax-table))
 
   ;; Because indentation is not redundant, we cannot safely reindent code.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -167,7 +167,7 @@
   ;; Workaround with org comments in order to properly
   ;; detect opening #[ and closing comments ]#
   (when (and (derived-mode-p 'org-mode)
-              (fboundp 'org-in-src-block-p) (org-in-src-block-p))
+             (fboundp 'org-in-src-block-p) (org-in-src-block-p))
     (modify-syntax-entry ?# ". 124b" nim-mode-syntax-table)
     (modify-syntax-entry ?[ ". 23" nim-mode-syntax-table))
 


### PR DESCRIPTION
Fixes `"File mode specification error: (error ‘org-element-at-point’ cannot be used in non-Org buffer" (org 9.6)`
