### PR TITLE
Fix 'org-element-at-point' eldoc error

### DIFF
--- a/nim-suggest.el
+++ b/nim-suggest.el
@@ -108,7 +108,8 @@ PROJECT-PATH is added as the last option."
        ;; and nimscript-mode (nimsuggest doesn't support yet).
        ;; https://github.com/nim-lang/nimsuggest/issues/29
        (not (memq major-mode '(org-mode nimscript-mode)))
-       (not (and (fboundp 'org-in-src-block-p)
+       (not (and (derived-mode-p 'org-mode)
+                 (fboundp 'org-in-src-block-p)
                  (or (org-in-src-block-p)
                      (org-in-src-block-p t))))))
 


### PR DESCRIPTION
#246 wasn't entirely fixed, the error still occurs when using eldoc to display symbol information. The code in this function is the same as in the other PR, it's just missing the same guard here.