### PR TITLE
fix(syntax): devdocs-lookup causes error 'wrong type characterp'

### DIFF
--- a/nim-syntax.el
+++ b/nim-syntax.el
@@ -180,7 +180,8 @@ is used to limit the scan."
 (defun nim-syntax--raw-string-p (pos)
   "Return non-nil if char of before POS is not word syntax class."
   ;; See also #212
-  (eq ?w (char-syntax (char-before pos))))
+  (when (> pos 1)
+    (eq ?w (char-syntax (char-before pos)))))
 
 (defun nim-syntax-stringify ()
   "Put `syntax-table' property correctly on single/triple double quotes."


### PR DESCRIPTION
Why?:
- When looking up some function documentation using devdocs-lookup, nim-syntax--raw-string-p errors out with the message 'wrong type charaterp'. Because point is at the beginning of the buffer, which makes pos = 1 and thus causes char-before to return nil, which then causes the error when calling char-syntax on nil.

This change addresses the need by:
- Add guarding when clause