### PR TITLE
Drop dependency on flycheck-nimsuggest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,15 @@ jobs:
           - 26.3
           - 27.2
           - 28.2
-          - 29.1
+          - 29.4
+          - 30.1
         experimental: [false]
+        exclude:
+        # Emacs 26.3 and 27.3 are not available for MacOS on Apple Silicon
+        - os: macos-latest
+          emacs-version: 26.3
+        - os: macos-latest
+          emacs-version: 27.2
         include:
         - os: ubuntu-latest
           emacs-version: snapshot

--- a/Cask
+++ b/Cask
@@ -10,6 +10,5 @@
  (depends-on "buttercup")
  (depends-on "epc")
  (depends-on "commenter")
- (depends-on "flycheck-nimsuggest")
  (depends-on "let-alist")
  (depends-on "cl-lib"))

--- a/Eask
+++ b/Eask
@@ -16,7 +16,6 @@
 (depends-on "epc" "0.1.1")
 (depends-on "let-alist" "1.0.1")
 (depends-on "commenter" "0.5.1")
-(depends-on "flycheck-nimsuggest" "0.8.1")
 
 (development
  (depends-on "buttercup")

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ This package provides (and requires Emacs 24.4 or higher version):
 - `nim-compile` command (*C-c C-c*), with error matcher for the
   compile buffer
 - Nimsuggest (alpha):
-  - on the fly linter using flycheck, or flymake (from Emacs 26)
-  - auto-completion with company-mode ("C-M-i" for manual completion)
+  - on the fly linting using flymake (from Emacs 26) or flycheck
+  - auto-completion support for most built-in or external Emacs
+    completion frameworks, e.g. completion-at-point or company-mode ("C-M-i" for manual
+    completion)
   - jump-to-definition (*M-.*, and *M-,* keys)
   - find-references (*M-?* key)
   - eldoc or help on hover in term of LSP
@@ -42,17 +44,20 @@ other minor modes such as ``flycheck``,``flymake`` (linting) and
 ``company`` (completion) that are responsible for editor integration.
 
 - ``flycheck`` and ``flymake`` are two alternative linting
-  engines. Before emacs version ``26.1`` ``flymake`` was pretty much
+  engines. As of Emacs ``26.1``, ``flymake`` is built into Emacs.
+  Before emacs version ``26.1`` ``flymake`` was pretty much
   outdated and the recommended linting engine was the external
   ``flycheck``.  But from version ``26.1`` onward, ``flymake`` is a
   good linting engine that comes with emacs.  But you should not use both
   at the same time.
-- ``flycheck-nimsuggest`` is a backend for flycheck. It builds the bridge
-  to ``nimsuggest-mode`` so that flycheck can visualize the linting
+- [``flycheck-nimsuggest``](https://github.com/yuutayamada/flycheck-nimsuggest)
+  is a backend for flycheck. It builds the bridge to
+  ``nimsuggest-mode`` so that flycheck can visualize the linting
   information that nimsuggest provides.
-- ``flycheck-nim`` is an alternative backend for flycheck that does
-  not interact with nimsuggest at all. Instead it uses the ``nim
-  check`` command and parses the output of that command.
+- [``flycheck-nim``](https://github.com/ALSchwalm/flycheck-nim) is an
+  alternative backend for flycheck that does not interact with
+  nimsuggest at all. Instead it uses the ``nim check`` command and
+  parses the output of that command.
 - ``flymake-nimsuggest`` is the backend for ``flymake`` to build the
   bridge to ``nimsuggest-mode``. It comes with ``nim-mode``, and it is
   activated automatically in nim files, when ``flymake-mode`` is on.

--- a/nim-mode.el
+++ b/nim-mode.el
@@ -8,7 +8,7 @@
 ;; Version: 0.4.2
 ;; Keywords: nim languages
 ;; Compatibility: GNU Emacs 24.4
-;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1") (flycheck-nimsuggest "0.8.1"))
+;; Package-Requires: ((emacs "24.4") (epc "0.1.1") (let-alist "1.0.1") (commenter "0.5.1"))
 
 ;; Taken over from James H. Fisher <jameshfisher@gmail.com>
 ;;
@@ -56,13 +56,16 @@
 ;;
 ;;   (setq nimsuggest-path "path/to/nimsuggest")
 ;;
-;; You may need to install below packages if you haven't installed yet.
+;; Flymake and completion-at-point support is enabled automatically by
+;; `nimsuggest-mode'.
 ;;
-;; -- Auto completion --
+;; Alternatively, You may want to install the optional packages below.
+;;
+;; -- Auto completion using company (optional) --
 ;; You can omit if you configured company-mode on 'prog-mode-hook
 ;;   (add-hook 'nimsuggest-mode-hook 'company-mode)  ; auto complete package
 ;;
-;; -- Auto lint --
+;; -- Auto lint using flycheck (optional) --
 ;; You can omit if you configured flycheck-mode on 'prog-mode-hook
 ;;
 ;;   (add-hook 'nimsuggest-mode-hook 'flycheck-mode) ; auto linter package


### PR DESCRIPTION
Hi, MELPA maintainer here with a drive-by fix for a packaging issue I noticed.

A major mode like this should not depend on opinionated frameworks like `flycheck`, but this package does so implicitly by depending on `flycheck-nimsuggest`. Flymake or LSP users need not have flycheck unnecessarily installed on their behalf.

This commit drops the declared dependency and makes it clear that it is optional and for the user to decide
whether to additionally install `flycheck-nimsuggest`. _Flymake_ support will continue to work out of the box for all users of Emacs 26+.

Cheers!